### PR TITLE
Updating linux script to install fixed version of driver

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -6,7 +6,7 @@ instances.
 
 The script support the following operating systems:
 
-* CentOS: versions 7 
+* CentOS: versions 7
 * CentOS Stream: version 8
 * Debian: versions 10 and 11
 * RHEL: versions 7 and 8
@@ -34,7 +34,7 @@ requirements:
 The `install_gpu_driver.py` script needs to be executed with root privileges
 (for example `sudo python3 install_gpu_driver.py`).
 
-Note: On CentOS and RHEL systems the script might trigger system reboot, it
+Note: On some systems the script might trigger system reboot, it
 needs to be restarted after the reboot is done.
 
 After the installation, you should restart your system to make sure everything

--- a/linux/README.md
+++ b/linux/README.md
@@ -6,11 +6,12 @@ instances.
 
 The script support the following operating systems:
 
-*   CentOS: versions 7 and 8
-*   Debian: versions 10 and 11
-*   RHEL: versions 7 and 8
-*   SUSE: version 15
-*   Ubuntu: version 18 and 20
+* CentOS: versions 7 
+* CentOS Stream: version 8
+* Debian: versions 10 and 11
+* RHEL: versions 7 and 8
+* Rocky: version 8
+* Ubuntu: version 18, 20 and 21
 
 Note: Just because an operating system is not supported by this script, doesn't
 mean that it's impossible to install NVIDIA drivers on it. You should check and
@@ -25,9 +26,8 @@ requirements:
 
 *   Python interpreter in version 3.6 installed (by default available in all
     supported OSes except CentOS 7 and RHEL 7).
-*   Access to Internet (the script needs to download the driver and CUDA toolkit
-    from OS package repository).
-*   At least one GPU unit installed.
+*   Access to Internet (the script needs to download the driver).
+*   (optional) At least one GPU unit attached.
 
 ## Running the script
 
@@ -46,11 +46,3 @@ The installation script logs its outputs to `/opt/google/gpu-installer/` folder.
 If you are facing any problems with the installation, this should be the first
 place to check for any errors. When asking for support, you will be asked to
 provide the log files from this folder.
-
-## Verifying installation
-
-You can run a verification procedure to check if the installation was
-successful. Run `python3 install_gpu_driver.py verify` command to create a
-temporary directory with CUDA code samples. The script will automatically build
-and run two simple examples: `deviceQuery` and `bandwidthTest` - if they build
-and run successfully, you can assume that your installation was successful!

--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 import argparse
 import atexit
-import glob
 import os
 import pathlib
 import re
 import shlex
 import subprocess
 import sys
-import tempfile
 from datetime import datetime
 from enum import Enum, auto
 
@@ -47,21 +45,25 @@ class System(Enum):
 # CentOS 7 and RHEL 7 require Python3 to be installed before this script can be run.
 # SLES and RHEL need a reboot after installation to load the driver.
 SUPPORTED_SYSTEMS = {
-    System.CentOS: {"7"},  # CentOS 8 is dead: https://www.centos.org/centos-linux-eol/
+    # CentOS 8 is dead: https://www.centos.org/centos-linux-eol/, but there's CentOS Stream 8
+    System.CentOS: {"7", "8"},
     System.Debian: {"10", "11"},
     System.Fedora: set(),
     System.RHEL: {"7", "8"},
-    System.Rocky: set(),
-    System.SUSE: {"15"},
-    System.Ubuntu: {"18", "20"}
+    System.Rocky: {"8"},
+    System.SUSE: set(),
+    System.Ubuntu: {"18", "20", "21"}
 }
+
+INSTALLER_DIR = pathlib.Path('/opt/google/gpu-installer/')
+DEPENDENCIES_INSTALLED_FLAG = INSTALLER_DIR / 'deps_installed.flag'
+INSTALLER_DIR.mkdir(parents=True, exist_ok=True)
 
 
 class Logger:
-    LOG_DIR = '/opt/google/gpu-installer/'
-    STDOUT_LOG = LOG_DIR + 'out.log'
+    STDOUT_LOG = INSTALLER_DIR / 'out.log'
     STDOUT_LOG_F = None
-    STDERR_LOG = LOG_DIR + 'err.log'
+    STDERR_LOG = INSTALLER_DIR / 'err.log'
     STDERR_LOG_F = None
 
     @classmethod
@@ -77,9 +79,8 @@ class Logger:
         """
         Create the LOG_DIR path and STD(OUT|ERR)_LOG files.
         """
-        pathlib.Path(cls.LOG_DIR).mkdir(parents=True, exist_ok=True)
-        pathlib.Path(cls.STDOUT_LOG).touch(exist_ok=True)
-        pathlib.Path(cls.STDERR_LOG).touch(exist_ok=True)
+        cls.STDOUT_LOG.touch(exist_ok=True)
+        cls.STDERR_LOG.touch(exist_ok=True)
 
         cls.STDOUT_LOG_F = open(cls.STDOUT_LOG, mode='a')
         cls.STDERR_LOG_F = open(cls.STDERR_LOG, mode='a')
@@ -141,12 +142,11 @@ def detect_gpu_device():
     """
     lspci = run('lspci')
     output = lspci.stdout.decode()
-    if "controller: NVIDIA Corporation" not in output:
+    for line in output.splitlines():
+        if "controller: NVIDIA Corporation" in line:
+            return re.findall("\[([\w\d\s]+)]", line)[0]
+    else:
         return None
-    if "Tesla K80" in output:
-        return "K80"
-
-    return "OTHER"
 
 
 def check_python_version():
@@ -233,24 +233,27 @@ def install_dependencies_centos_rhel_rocky(system: System, version: str):
     """
     Installs required kernel-related packages and pciutils for CentOS and RHEL.
     """
-    kernel_version = run("uname -r").stdout.decode().strip()
-
     if version.startswith("8"):
         binary = "dnf"
     else:
         binary = "yum"
     run(f"{binary} clean all")
+    run(f"{binary} update -y")
     kernel_install = run(f"{binary} install -y kernel")
     if "already installed" not in kernel_install.stdout.decode():
         run("reboot")  # Restart the system after installing the kernel modules
         sys.exit(0)
     if system == System.Rocky:
         run("dnf config-manager --set-enabled powertools")
+        run("dnf install -y epel-release")
     elif system == System.CentOS and version.startswith("8"):
         run("dnf config-manager --set-enabled powertools")
-        run("dnf install epel-release epel-next-release")
+        run("dnf install -y epel-release epel-next-release")
     elif system == System.RHEL and version.startswith("8"):
-        run("dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm")
+        run("dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm")
+    elif system in (System.RHEL, System.CentOS) and version.startswith("9"):
+        run("dnf install -y https://dl.fedoraproject.org/pub/epel/next/9/Everything/x86_64/Packages/e/epel-next-release-9-1.el9.next.noarch.rpm")
+        run("dnf install -y https://dl.fedoraproject.org/pub/epel/next/9/Everything/x86_64/Packages/e/epel-release-9-1.el9.next.noarch.rpm")
 
     run(f"{binary} install -y kernel-devel epel-release "
         f"kernel-headers pciutils gcc make dkms acpid "
@@ -258,11 +261,20 @@ def install_dependencies_centos_rhel_rocky(system: System, version: str):
     return
 
 
+def install_dependencies_sles(system: System, version: str):
+    # zypper install gcc make kernel-devel kernel-source
+    # zypper install -t pattern devel_C_C++ devel_kernel
+    # zypper install dkms
+    pass
+    # For now, there is not SLES script working.
+
+
 def install_dependencies_debian_ubuntu(system: System, version: str):
     """
     Installs kernel-related packages and pciutils for Debian and Ubuntu.
     """
     kernel_version = run("uname -r").stdout.decode().strip()
+    run("apt update")
     run(f"apt install -y linux-headers-{kernel_version} "
         "software-properties-common pciutils gcc make")
     return
@@ -274,39 +286,24 @@ def install_dependencies(system: System, version: str):
     This function may restart the system after installing some of the packages,
     in such situations the script should just be started again.
     """
+    if DEPENDENCIES_INSTALLED_FLAG.is_file():
+        return
+
     if system in (System.CentOS, System.RHEL, System.Rocky):
         install_dependencies_centos_rhel_rocky(system, version)
-        return
     elif system in (System.Debian, System.Ubuntu):
         install_dependencies_debian_ubuntu(system, version)
-        return
     elif system == System.SUSE:
-        return
+        install_dependencies_sles(system, version)
     else:
         raise RuntimeError("Unsupported operating system!")
 
-
-def install_driver(system: System, version: str):
-    """
-    Installs the GPU driver. The installation instructions are taken from
-    https://developer.nvidia.com/cuda-downloads
-    """
-    if system == System.CentOS:
-        install_driver_centos(version)
-    elif system == System.RHEL:
-        install_driver_rhel(version)
-    elif system == System.SUSE:
-        install_driver_suse()
-    elif system == System.Ubuntu:
-        install_driver_ubuntu(version)
-    elif system == System.Debian:
-        install_driver_debian()
-    else:
-        raise RuntimeError("Unsupported operating system.")
+    with DEPENDENCIES_INSTALLED_FLAG.open(mode='w') as flag:
+        flag.write('1')
 
 
 def install_driver_runfile():
-    if detect_gpu_device() == 'K80':
+    if detect_gpu_device() == 'Tesla K80':
         run("curl -fSsl -O https://us.download.nvidia.com/tesla/470.103.01/NVIDIA-Linux-x86_64-470.103.01.run")
         run("sh NVIDIA-Linux-x86_64-470.103.01.run -s")
     else:
@@ -314,125 +311,19 @@ def install_driver_runfile():
         run("sh NVIDIA-Linux-x86_64-495.46.run -s")
 
 
-def install_driver_centos(version: str):
-    if version.startswith("7"):
-        run("yum install -y yum-utils epel-release")
-        run("yum-config-manager --add-repo "
-            "https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo")
-        run("yum clean all")
-        run("yum install -y nvidia-driver-latest-dkms cuda")
-        run("yum install -y cuda-drivers")
-        return
-    else:
-        run("dnf -y install epel-release")
-        run("dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo")
-        run("dnf clean all")
-        run("dnf -y module install nvidia-driver:latest-dkms")
-        run("dnf -y install cuda")
-        return
-
-
-def install_driver_debian():
-    run(f"apt-key adv --fetch-keys "
-        f"https://developer.download.nvidia.com/compute/cuda/repos/debian10/x86_64/7fa2af80.pub")
-    run(f'add-apt-repository "deb '
-        f'https://developer.download.nvidia.com/compute/cuda/repos/debian10/x86_64/ /"')
-    run(f'add-apt-repository contrib')
-    run("apt update")
-    env = os.environ.copy()
-    env['DEBIAN_FRONTEND'] = 'noninteractive'
-    run("apt install -y cuda", environment=env)
-
-
-def install_driver_ubuntu(version):
-    version_nodot = "".join(version.split("."))
-    run(f"curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{version_nodot}/x86_64/cuda-ubuntu{version_nodot}.pin")
-    run(f"mv cuda-ubuntu{version_nodot}.pin /etc/apt/preferences.d/cuda-repository-pin-600")
-    run(f"apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{version_nodot}/x86_64/7fa2af80.pub")
-    run(f'add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{version_nodot}/x86_64/ /"')
-    run("apt update")
-    run("apt install -y cuda")
-
-
-def install_driver_suse():
-    run("zypper addrepo https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/cuda-sles15.repo")
-    run("zypper --gpg-auto-import-keys refresh")
-    run("zypper install -y cuda")
-
-
-def install_driver_rhel(version):
-    if version.startswith("7"):
-        run("yum install -y yum-utils epel-release")
-        run("yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo")
-        run("yum clean all")
-        run("yum -y install nvidia-driver-latest-dkms cuda")
-        run("yum -y install cuda-drivers")
-    else:
-        run("dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm")
-        run("dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo")
-        run("dnf clean all")
-        run("dnf -y module install nvidia-driver:latest-dkms")
-        run("dnf -y install cuda")
-
-
 def post_install_steps():
     """
-    Execute post-installation steps as described on
-    https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions
+    Write the success message to log.
     """
-    # Update PATH and LD_LIBRARY_PATH env variables for everyone
-    with open('/etc/profile.d/cuda.sh', mode='w') as env_conf:
-        env_conf.write("# CUDA Toolkit settings" + os.linesep)
-        env_conf.write("export PATH=/usr/local/cuda-11/bin:$PATH" + os.linesep)
-        env_conf.write("export LD_LIBRARY_PATH=/usr/local/cuda-11/lib64:$LD_LIBRARY_PATH" + os.linesep)
-    # Let's mark that the installation was successful.
-    with open(Logger.LOG_DIR + 'success', mode='w') as success_file:
+    with open(INSTALLER_DIR + 'success', mode='w') as success_file:
         success_file.write("Installation was completed on {}".format(datetime.now()))
-
-
-def run_test(test_path: pathlib.PosixPath, test_bin: str) -> bool:
-    print(f"Building {test_bin} test...")
-    make = run("make", cwd=test_path, silent=True)
-    if ">>> Waiving build. Minimum GCC version required is" in make.stdout.decode():
-        # RHEL 7 and CentOS 7 have GCC in version 4.8, which is too low for some tests
-        print(f"Skipping {test_bin} test, as it requires newer version of GCC: ")
-        print(make.stdout.decode().splitlines()[0])
-        return True
-    print(f"Running the {test_bin} test...")
-    dev_query = run(str((test_path / test_bin).absolute()), cwd=test_path, silent=True)
-    out = dev_query.stdout.decode()
-    print(out)
-    print(dev_query.stderr.decode())
-    if "Result = PASS" in out:
-        print(f"{test_bin} test passed.")
-        return True
-    else:
-        print(f"{test_bin} test failed!")
-        return False
 
 
 def verify_installation():
     """
-    Compile sample programs provided by NVIDIA to check if the installation was successful.
+    Try running nvidia-smi to check if it detects the graphics card.
     """
-    try:
-        sample_install_script = glob.glob("/usr/local/cuda-11/bin/cuda-install-samples*.sh")[0]
-        cuda_version = re.findall(r"cuda-install-samples-(\d+\.\d+)\.sh", sample_install_script)[0]
-    except IndexError:
-        raise RuntimeError("Couldn't find the cuda-install-samples script to validate installation!")
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        print(f"Setting up CUDA samples in {tmp_dir}...")
-        run(f"{sample_install_script} {tmp_dir}", silent=True)
-        sample_dir = pathlib.PosixPath(tmp_dir, f"NVIDIA_CUDA-{cuda_version}_Samples")
-
-        dev_query_path = sample_dir / "1_Utilities" / "deviceQuery"
-        bandwidth_test_path = sample_dir / "1_Utilities" / "bandwidthTest"
-        passed = True
-        passed &= run_test(dev_query_path, "deviceQuery")
-        passed &= run_test(bandwidth_test_path, "bandwidthTest")
-
-    sys.exit(0 if passed else 1)
 
 
 def parse_args():
@@ -475,7 +366,7 @@ def main():
             print("There doesn't seem to be a GPU unit connected to your system. "
                   "Aborting drivers installation.")
             sys.exit(0)
-        install_driver(system, version)
+        install_driver_runfile()
         post_install_steps()
 
 


### PR DESCRIPTION
Fixing #4 
Fixing #3 
Fixing #2 

The script will now install a fixed version of the NVIDIA driver, appropriate to the GPU attached. 

It will no longer install the whole CUDA suite. Only the driver.

Tested with:
```
CentOS 7 | a100
CentOS 8 | K80

Debian 10 | P4
Debian 11 | T4

RHEL 7 | V100
RHEL 8 | A100

Rocky 8 | K80

Ubuntu 18 | V100
Ubuntu 20 | V100
Ubuntu 21 | A100
```