### PR TITLE
Handle unknown name of Nvidia driver

### DIFF
--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -139,7 +139,8 @@ def detect_gpu_device():
     output = lspci.stdout.decode()
     for line in output.splitlines():
         if "controller: NVIDIA Corporation" in line:
-            return re.findall("\[([\w\d\s]+)]", line)[0]
+            driver_name = re.findall("\[([\w\d\s]+)]", line)
+            return driver_name[0] if driver_name else True
     else:
         return None
 


### PR DESCRIPTION
As described in #8, the installation script fails when `lspci` indicates that an Nvidia driver is attached but does not reference the driver's name according to the expected regex.  Tested these changes on Ubuntu 18.04 with an attached T4.