### PR TITLE
Adding a script that allows for automatic testing of the Linux installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+__pycache__

--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -88,6 +88,7 @@ class Logger:
     def print_out(cls, msg: str, end=os.linesep, print_=True):
         if cls.STDOUT_LOG_F:
             cls.STDOUT_LOG_F.write(msg + end)
+            cls.STDOUT_LOG_F.flush()
         if print_:
             print(msg, end=end, file=sys.stdout)
 
@@ -95,6 +96,7 @@ class Logger:
     def print_err(cls, msg: str, end=os.linesep, print_=True):
         if cls.STDERR_LOG_F:
             cls.STDERR_LOG_F.write(msg + end)
+            cls.STDERR_LOG_F.flush()
         if print_:
             print(msg, end=end, file=sys.stderr)
 

--- a/linux/startup_script.sh
+++ b/linux/startup_script.sh
@@ -1,0 +1,4 @@
+mkdir -p /opt/google
+cd /opt/google || exit
+curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py
+python3 install_gpu_driver.py

--- a/linux/startup_script.sh
+++ b/linux/startup_script.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if which nvidia-smi
+then
+  exit
+fi
+
 mkdir -p /opt/google
 cd /opt/google || exit
 

--- a/linux/startup_script.sh
+++ b/linux/startup_script.sh
@@ -1,4 +1,16 @@
+#!/bin/bash
 mkdir -p /opt/google
 cd /opt/google || exit
+
+if ! which python3 > /dev/null
+then
+  if which yum > /dev/null
+  then
+    yum install -y python3
+  else
+    apt-get install -y python3
+  fi
+fi
+
 curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py
 python3 install_gpu_driver.py

--- a/linux/tests/README.md
+++ b/linux/tests/README.md
@@ -10,7 +10,7 @@ manually on local developer machine. Required steps:
 3. Install required Python packages `pip install -Ur requirements.txt`
 4. Run test using `pytest` command. You can speed up the 
    process by using parallel execution with 
-   `pytest --workers 1 --tests-per-worker 50`. Remember to use only one
+   `pytest --workers 1 --tests-per-worker 10`. Remember to use only one
   process, as the tests use thread semaphores to make sure they don't exceed
   GPU quota
 

--- a/linux/tests/README.md
+++ b/linux/tests/README.md
@@ -1,0 +1,20 @@
+# Automated GPU driver installation testing
+
+The current version of automated testing is meant to be run
+manually on local developer machine. Required steps:
+
+1. Use `gcloud auth application-default login` to configure
+   account you want to use for testing.
+2. (optional) Use `gcloud config set project $PROJECT` to
+   specify a project you want to use for testing.
+3. Install required Python packages `pip install -Ur requirements.txt`
+4. Run test using `pytest` command. You can speed up the 
+   process by using parallel execution with 
+   `pytest -n auto`
+
+
+Note: The VMs created for this test don't have external IP
+addresses assigned, so it's required for the project
+they are created in to have Cloud NAT configured for the
+default VPC Network. Without it, the instances won't be
+able to download necessary drivers.

--- a/linux/tests/README.md
+++ b/linux/tests/README.md
@@ -10,7 +10,9 @@ manually on local developer machine. Required steps:
 3. Install required Python packages `pip install -Ur requirements.txt`
 4. Run test using `pytest` command. You can speed up the 
    process by using parallel execution with 
-   `pytest -n auto`
+   `pytest --workers 1 --tests-per-worker 50`. Remember to use only one
+  process, as the tests use thread semaphores to make sure they don't exceed
+  GPU quota
 
 
 Note: The VMs created for this test don't have external IP

--- a/linux/tests/requirements.txt
+++ b/linux/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.1
+pytest-xdist==2.5.0
 google-cloud-compute==1.1.0

--- a/linux/tests/requirements.txt
+++ b/linux/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest==7.1.1
+google-cloud-compute==1.1.0

--- a/linux/tests/requirements.txt
+++ b/linux/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.1
-pytest-xdist==2.5.0
+pytest-parallel==0.1.1
 google-cloud-compute==1.1.0

--- a/linux/tests/test_installations.py
+++ b/linux/tests/test_installations.py
@@ -29,7 +29,7 @@ from google.cloud import compute_v1
 
 PROJECT = google.auth.default()[1]
 
-INSTALLATION_TIMEOUT = 900  # 15 minutes
+INSTALLATION_TIMEOUT = 1200  # 20 minutes
 
 # Cloud project and family
 OPERATING_SYSTEMS = (
@@ -262,9 +262,3 @@ def _test_body(zone: str, instance_name: str, gpu: str, ssh_key: str):
         timeout=60
     )
     assert gpu.lower() in process.stdout.lower()
-    # Do this until we see success or timeout
-    # I need to prepare a sshkey first
-    #  gcloud compute ssh gpu-test-centos-7-v100-ba1c8f00ed --zone us-central1-a --command="ls /opt/google/gpu-installer" 2> /dev/null
-    # Once there is success file, we can try running `nvidia-smi -L` to check if we see the card we want
-    # nvidia-smi -L
-    # GPU 0: Tesla V100-SXM2-16GB (UUID: GPU-14e93b7e-86df-27ae-7d7a-3cd4e3a81004)

--- a/linux/tests/test_installations.py
+++ b/linux/tests/test_installations.py
@@ -1,0 +1,139 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+
+import pytest
+import uuid
+import google.auth
+from google.cloud import compute_v1
+
+PROJECT = google.auth.default()[1]
+
+# Cloud project and family
+OPERATING_SYSTEMS = (
+    ("centos-cloud", "centos-7"),
+    ("centos-cloud", "centos-stream-8"),
+    ("debian-cloud", "debian-10"),
+    ("debian-cloud", "debian-11"),
+    ("rhel-cloud", "rhel-7"),
+    ("rhel-cloud", "rhel-8"),
+    ("rocky-linux-cloud", "rocky-linux-8"),
+    ("ubuntu-os-cloud", "ubuntu-2004-lts"),
+    ("ubuntu-os-cloud", "ubuntu-1804-lts"),
+    ("ubuntu-os-cloud", "ubuntu-2110"),
+
+)
+
+GPUS = {
+    "A100": "nvidia-tesla-a100",
+    "K80": "nvidia-tesla-k80",
+    "P4": "nvidia-tesla-p4",
+    "T4": "nvidia-tesla-t4",
+    "P100": "nvidia-tesla-p100",
+    "V100": "nvidia-tesla-v100",
+}
+
+ZONES = {
+    "A100": "us-central1-f",
+    "K80": "us-central1-a",
+    "P4": "us-central1-a",
+    "T4": "us-central1-b",
+    "P100": "us-central1-c",
+    "V100": "us-central1-a",
+}
+
+MACHINE_TYPES = {
+    "A100": "a2-highgpu-1g",
+    "K80": "n1-standard-8",
+    "P4": "n1-standard-8",
+    "T4": "n1-standard-8",
+    "P100": "n1-standard-8",
+    "V100": "n1-standard-8",
+}
+
+
+def get_image_from_family(project: str, family: str) -> compute_v1.Image:
+    """
+    Retrieve the newest image that is part of a given family in a project.
+    Args:
+        project: project ID or project number of the Cloud project you want to get image from.
+        family: name of the image family you want to get image from.
+    Returns:
+        An Image object.
+    """
+    image_client = compute_v1.ImagesClient()
+    # List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details
+    newest_image = image_client.get_from_family(project=project, family=family)
+    return newest_image
+
+
+def get_boot_disk(source_image_link: str, zone: str) -> compute_v1.AttachedDisk:
+    boot_disk = compute_v1.AttachedDisk()
+    initialize_params = compute_v1.AttachedDiskInitializeParams()
+    initialize_params.source_image = source_image_link
+    initialize_params.disk_size_gb = 100
+    initialize_params.disk_type = f"zones/{zone}/diskTypes/pd-standard"
+    boot_disk.initialize_params = initialize_params
+    # Remember to set auto_delete to True if you want the disk to be deleted when you delete
+    # your VM instance.
+    boot_disk.auto_delete = True
+    boot_disk.boot = True
+    return boot_disk
+
+
+def test_install_driver():
+    opsys = OPERATING_SYSTEMS[0]
+    gpu = 'V100'
+
+    zone = ZONES[gpu]
+
+    op_sys_image = get_image_from_family(*opsys)
+    disks = [get_boot_disk(op_sys_image.self_link, zone)]
+
+    # Use the network interface provided in the network_link argument.
+    network_interface = compute_v1.NetworkInterface()
+    network_interface.name = "global/networks/default"
+
+    # GPUs
+    accelerator = compute_v1.AcceleratorConfig()
+    accelerator.accelerator_count = 1
+    accelerator.accelerator_type = f"zones/{zone}/acceleratorTypes/{GPUS[gpu]}"
+
+    instance = compute_v1.Instance()
+    instance.machine_type = f"zones/{zone}/machineTypes/{MACHINE_TYPES[gpu]}"
+    instance_name = f"gpu-test-{opsys[1]}-{gpu}-" + uuid.uuid4()[:10]
+    instance.name = instance_name
+    instance.disks = disks
+    instance.accelerators = [accelerator]
+
+    # Prepare the request to insert an instance.
+    request = compute_v1.InsertInstanceRequest()
+    request.zone = zone
+    request.project = PROJECT
+    request.instance_resource = instance
+
+    instance_client = compute_v1.InstancesClient()
+    operation = instance_client.insert_unary(request)
+    operation_client = compute_v1.ZoneOperationsClient()
+    operation = operation_client.wait(project=PROJECT, zone=zone, operation=operation.name)
+
+    if operation.error:
+        print(f"Error during instance {instance_name} creation:", operation.error, file=sys.stderr)
+        raise RuntimeError(operation.error)
+
+    if operation.warnings:
+        print(f"Warnings during instance {instance_name} creation:\n", file=sys.stderr)
+        for warning in operation.warnings:
+            print(f" - {warning.code}: {warning.message}", file=sys.stderr)
+

--- a/linux/tests/test_installations.py
+++ b/linux/tests/test_installations.py
@@ -34,24 +34,24 @@ INSTALLATION_TIMEOUT = 30*60  # 30 minutes
 # Cloud project and family
 OPERATING_SYSTEMS = (
     ("centos-cloud", "centos-7"),
-    # ("centos-cloud", "centos-stream-8"),
-    # ("debian-cloud", "debian-10"),
-    # ("debian-cloud", "debian-11"),
-    # ("rhel-cloud", "rhel-7"),
-    # ("rhel-cloud", "rhel-8"),
-    # ("rocky-linux-cloud", "rocky-linux-8"),
-    # ("ubuntu-os-cloud", "ubuntu-2004-lts"),
-    # ("ubuntu-os-cloud", "ubuntu-1804-lts"),
-    # ("ubuntu-os-cloud", "ubuntu-2110"),
+    ("centos-cloud", "centos-stream-8"),
+    ("debian-cloud", "debian-10"),
+    ("debian-cloud", "debian-11"),
+    ("rhel-cloud", "rhel-7"),
+    ("rhel-cloud", "rhel-8"),
+    ("rocky-linux-cloud", "rocky-linux-8"),
+    ("ubuntu-os-cloud", "ubuntu-2004-lts"),
+    ("ubuntu-os-cloud", "ubuntu-1804-lts"),
+    ("ubuntu-os-cloud", "ubuntu-2110"),
 )
 
 GPUS = {
-    # "A100": "nvidia-tesla-a100",
-    # "K80": "nvidia-tesla-k80",
+    "A100": "nvidia-tesla-a100",
+    "K80": "nvidia-tesla-k80",
     "P4": "nvidia-tesla-p4",
-    # "T4": "nvidia-tesla-t4",
-    # "P100": "nvidia-tesla-p100",
-    # "V100": "nvidia-tesla-v100",
+    "T4": "nvidia-tesla-t4",
+    "P100": "nvidia-tesla-p100",
+    "V100": "nvidia-tesla-v100",
 }
 
 GPU_QUOTA_SEMAPHORES = {
@@ -227,9 +227,8 @@ def test_install_driver_for_system(ssh_key: str, opsys: Tuple[str, str], gpu: st
             _test_body(zone, instance_name, gpu, ssh_key)
         finally:
             try:
-                pass
-                # operation = instance_client.delete_unary(project=PROJECT, zone=zone, instance=instance_name)
-                # operation_client.wait(project=PROJECT, zone=zone, operation=operation.name)
+                operation = instance_client.delete_unary(project=PROJECT, zone=zone, instance=instance_name)
+                operation_client.wait(project=PROJECT, zone=zone, operation=operation.name)
             except google.api_core.exceptions.NotFound:
                 # The instance was not properly created at all.
                 pass

--- a/linux/tests/test_installations.py
+++ b/linux/tests/test_installations.py
@@ -28,29 +28,29 @@ from google.cloud import compute_v1
 
 PROJECT = google.auth.default()[1]
 
-INSTALLATION_TIMEOUT = 600  # 10 minutes
+INSTALLATION_TIMEOUT = 900  # 15 minutes
 
 # Cloud project and family
 OPERATING_SYSTEMS = (
-    ("centos-cloud", "centos-7"),
+    # ("centos-cloud", "centos-7"),
     ("centos-cloud", "centos-stream-8"),
-    ("debian-cloud", "debian-10"),
-    ("debian-cloud", "debian-11"),
+    # ("debian-cloud", "debian-10"),
+    # ("debian-cloud", "debian-11"),
     ("rhel-cloud", "rhel-7"),
     ("rhel-cloud", "rhel-8"),
-    ("rocky-linux-cloud", "rocky-linux-8"),
-    ("ubuntu-os-cloud", "ubuntu-2004-lts"),
-    ("ubuntu-os-cloud", "ubuntu-1804-lts"),
-    ("ubuntu-os-cloud", "ubuntu-2110"),
+    # ("rocky-linux-cloud", "rocky-linux-8"),
+    # ("ubuntu-os-cloud", "ubuntu-2004-lts"),
+    # ("ubuntu-os-cloud", "ubuntu-1804-lts"),
+    # ("ubuntu-os-cloud", "ubuntu-2110"),
 )
 
 GPUS = {
-    "A100": "nvidia-tesla-a100",
-    "K80": "nvidia-tesla-k80",
+    # "A100": "nvidia-tesla-a100",
+    # "K80": "nvidia-tesla-k80",
     "P4": "nvidia-tesla-p4",
-    "T4": "nvidia-tesla-t4",
-    "P100": "nvidia-tesla-p100",
-    "V100": "nvidia-tesla-v100",
+    # "T4": "nvidia-tesla-t4",
+    # "P100": "nvidia-tesla-p100",
+    # "V100": "nvidia-tesla-v100",
 }
 
 ZONES = {
@@ -184,12 +184,12 @@ def test_install_driver(ssh_key: str, opsys: Tuple[str, str], gpu: str):
         _test_body(zone, instance_name, gpu, ssh_key)
     finally:
         pass
-        try:
-            operation = instance_client.delete_unary(project=PROJECT, zone=zone, instance=instance_name)
-            operation = operation_client.wait(project=PROJECT, zone=zone, operation=operation.name)
-        except google.api_core.exceptions.NotFound:
-            # The instance was not properly created at all.
-            pass
+        # try:
+        #     operation = instance_client.delete_unary(project=PROJECT, zone=zone, instance=instance_name)
+        #     operation = operation_client.wait(project=PROJECT, zone=zone, operation=operation.name)
+        # except google.api_core.exceptions.NotFound:
+        #     # The instance was not properly created at all.
+        #     pass
 
 
 def _test_body(zone: str, instance_name: str, gpu: str, ssh_key: str):


### PR DESCRIPTION
The script will create all combinations of supported operating systems and GPU types and run the installation script from the main branch of this repository.

In the future I will make it run with a local/different copy of the installation script, so it can be easily used to test new script versions before they are merged to main.