### PR TITLE
check nvidia-smi exit code

### DIFF
--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -227,7 +227,10 @@ def check_driver_installed() -> bool:
     If it's available, that means the driver is already installed.
     """
     process = run("which nvidia-smi", check=False)
-    return process.returncode == 0
+    if process.returncode != 0:
+        return False
+    process2 = run("nvidia-smi", check=False)
+    return process2.returncode == 0
 
 
 def install_dependencies_centos_rhel_rocky(system: System, version: str) -> bool:


### PR DESCRIPTION
After a kernel upgrade, the installed NVIDIA driver may stop working (see below). So check the exit code of `nvidia-smi` to confirm the driver is working.
```
$ nvidia-smi
NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running.
```