### PR TITLE
Removing prompts from Windows script

### DIFF
--- a/windows/install_gpu_driver.ps1
+++ b/windows/install_gpu_driver.ps1
@@ -47,7 +47,7 @@ function Find-GPU {
 # Check if the Driver is already installed
 function Check-Driver {
     try {
-        &'C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe'
+        &'nvidia-smi.exe'
         Write-Output 'Driver is already installed.'
         Exit
     }


### PR DESCRIPTION
Fixes #22 

The script should not wait for user input. It's meant to be used hands-off in automation.

Script will no longer wait for user to press any key and just install the driver if it's not there. Even if there's no GPU installed.