### PR TITLE
Revert "debian/ubuntu kernel headers: properly use available headers …

### DIFF
--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -285,12 +285,13 @@ def install_dependencies_sles(system: System, version: str) -> bool:
     # For now, there is not SLES script working.
 
 
-def install_dependencies_debian_ubuntu(system: System, version: str, kernel_package) -> bool:
+def install_dependencies_debian_ubuntu(system: System, version: str) -> bool:
     """
     Installs kernel-related packages and pciutils for Debian and Ubuntu.
     """
+    kernel_version = run("uname -r").stdout.decode().strip()
     run("apt update")
-    run(f"apt install -y {kernel_package} "
+    run(f"apt install -y linux-headers-{kernel_version} "
         "software-properties-common pciutils gcc make dkms")
     if system == System.Ubuntu and version.startswith("22"):
         run("update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12")
@@ -322,10 +323,8 @@ def install_dependencies(system: System, version: str):
 
     if system in (System.CentOS, System.RHEL, System.Rocky):
         reboot_flag = install_dependencies_centos_rhel_rocky(system, version)
-    elif system == System.Debian:
-        reboot_flag = install_dependencies_debian_ubuntu(system, version, "linux-headers-cloud-amd64")
-    elif system == System.Ubuntu:
-        reboot_flag = install_dependencies_debian_ubuntu(system, version, "linux-headers-gcp")
+    elif system in (System.Debian, System.Ubuntu):
+        reboot_flag = install_dependencies_debian_ubuntu(system, version)
     elif system == System.SUSE:
         reboot_flag = install_dependencies_sles(system, version)
     else:


### PR DESCRIPTION
…(#26)"

This reverts commit 93ce96a9f9f41d73b569ae4b71449d1b0c8f267b.

Given that Nvidia's script will also assume the currently running kernel to construct it's paths for source and install this patch renders partially right. Let's revert it for now until we have validated the use of the arguments to source and install dirs.