### PR TITLE
New cuda installer tool

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -1,48 +1,47 @@
-# Installation for Linux.
+# Installation for Linux
 
-In the `install_gpu_driver.py` you can find a script that automates installation
-of newer GPU drivers for NVIDIA GPU drivers available for Google Compute Engine
-instances.
+The recommended way to install NVIDIA GPU drivers and CUDA Toolkit for Google Cloud Compute Engine 
+instances is through the cuda_installer tool. Look for the newest version in the
+[releases](https://github.com/GoogleCloudPlatform/compute-gpu-installation/releases)
+section of this repository.
 
-The script support the following operating systems:
+The `install_gpu_driver.py` script is still available to not break existing setups,
+but is considered deprecated and should not be used anymore.
 
-* CentOS: versions 7
-* CentOS Stream: version 8
-* Debian: versions 10 and 11
-* RHEL: versions 7 and 8
-* Rocky: version 8
-* Ubuntu: version 20 and 21
+The tool supports following operating systems (x86_64/amd64 architecture):
 
-Note: Just because an operating system is not supported by this script, doesn't
-mean that it's impossible to install NVIDIA drivers on it. You should check and
-try instructions on
-[NVIDIAs website](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
-to discover other ways of installing drivers.
+* Debian: versions 10, 11 and 12
+* RHEL: versions 8 and 9
+* Rocky: version 8 and 9
+* Ubuntu: version 20, 22 and 24
+
+Note: Just because an operating system is not listed as supported by this tool,  
+it doesn't mean that it's impossible to install NVIDIA drivers on it. You should check and
+try instructions on [NVIDIAs website](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) to discover other ways of installing drivers.
 
 ## Requirements
 
 The system on which you want to run the script needs to meet the following
 requirements:
 
-*   Python interpreter in version 3.6 installed (by default available in all
-    supported OSes except CentOS 7 and RHEL 7).
-*   Access to Internet (the script needs to download the driver).
-*   (optional) At least one GPU unit attached.
+*   Python interpreter in version 3.6 or newer installed.
+*   Access to Internet (the script needs to download the driver and CUDA tookit).
+*   At least one GPU unit attached.
 
-## Running the script
+## Running the tool
 
-The `install_gpu_driver.py` script needs to be executed with root privileges
-(for example `sudo python3 install_gpu_driver.py`).
+The `cuda_installer.pyz` script needs to be executed with root privileges
+(for example `sudo python3 cuda_installer.pyz`).
 
-Note: On some systems the script might trigger system reboot, it
-needs to be restarted after the reboot is done.
+Note: During the installation the script will trigger system reboots. After a
+reboot, the script needs to be started again to continue the installation process.
 
-After the installation, you should restart your system to make sure everything
-is initialized properly and working.
+After successfully installation, the tool will restart your system once more to make 
+sure everything is initialized properly and working system wide.
 
 ## Script output
 
-The installation script logs its outputs to `/opt/google/gpu-installer/` folder.
+The installation tool logs its outputs to `/opt/google/cuda-installer/` folder.
 If you are facing any problems with the installation, this should be the first
 place to check for any errors. When asking for support, you will be asked to
 provide the log files from this folder.

--- a/linux/cuda_installer/__main__.py
+++ b/linux/cuda_installer/__main__.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from logger import logger
+
+# Need to import all the subpackages here, or the program fails for Python 3.6
+from os_installers import get_installer, debian, ubuntu, rhel, rocky
+import os
+import config
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Manage GPU drivers and CUDA toolkit installation.')
+    parser.add_argument("command", choices=[
+        'install_driver', 'install_cuda', 'verify_driver', 'verify_cuda', 'uninstall_driver',
+        'kernel_update'], help="Install GPU driver from NVIDIA package repository.")
+    # subparsers = parser.add_subparsers(help="Select action you want to take.", required=True)
+
+    # install_driver_parser = subparsers.add_parser('install_driver', help='Install GPU driver.')
+    # install_cuda_parser = subparsers.add_parser('install_cuda', help='Install CUDA toolkit.')
+    # verify_driver_parser = subparsers.add_parser('verify_driver', help='Verify GPU driver installation.')
+    # verify_cuda_parser = subparsers.add_parser('verify_cuda', help='Verify CUDA toolkit installation.')
+    # uninstall_driver_parser = subparsers.add_parser('uninstall_driver', help='Uninstall GPU driver.')
+    # uninstall_cuda_parser = subparsers.add_parser('uninstall_cuda', help='Uninstall CUDA toolkit.')
+    # update_kernel = subparsers.add_parser('update_kernel', help='Update system kernel if an update is available.')
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    if os.geteuid() != 0:
+        print("This script needs to be run with root privileges!")
+        sys.exit(1)
+    args = parse_args()
+    logger.info(f"Switching to working directory: {config.INSTALLER_DIR}")
+    os.chdir(config.INSTALLER_DIR)
+    installer = get_installer()
+
+    if args.command == 'install_driver':
+        installer.install_driver()
+    elif args.command == "verify_driver":
+        if installer.verify_driver(verbose=True):
+            sys.exit(0)
+        else:
+            sys.exit(1)
+    elif args.command == "uninstall_driver":
+        installer.uninstall_driver()
+    elif args.command == "install_cuda":
+        installer.install_cuda()

--- a/linux/cuda_installer/__main__.py
+++ b/linux/cuda_installer/__main__.py
@@ -48,3 +48,5 @@ if __name__ == '__main__':
         installer.uninstall_driver()
     elif args.command == "install_cuda":
         installer.install_cuda()
+    elif args.command == "verify_cuda":
+        installer.verify_cuda()

--- a/linux/cuda_installer/__main__.py
+++ b/linux/cuda_installer/__main__.py
@@ -1,34 +1,55 @@
 #!/usr/bin/env python3
-import argparse
-import sys
-from logger import logger
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import argparse
+import os
+import sys
+
+import config
+from logger import logger
 # Need to import all the subpackages here, or the program fails for Python 3.6
 from os_installers import get_installer, debian, ubuntu, rhel, rocky
-import os
-import config
+
+
+# Mentioning the packages from import above, so automatic import cleanups don't remove them
+del debian
+del ubuntu
+del rhel
+del rocky
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Manage GPU drivers and CUDA toolkit installation.')
-    parser.add_argument("command", choices=[
-        'install_driver', 'install_cuda', 'verify_driver', 'verify_cuda', 'uninstall_driver',
-        'kernel_update'], help="Install GPU driver from NVIDIA package repository.")
-    # subparsers = parser.add_subparsers(help="Select action you want to take.", required=True)
+    parser = argparse.ArgumentParser(
+        description="Manage GPU drivers and CUDA toolkit installation."
+    )
+    parser.add_argument(
+        "command",
+        choices=[
+            "install_driver",
+            "install_cuda",
+            "verify_driver",
+            "verify_cuda",
+            "uninstall_driver",
+        ],
+        help="Install GPU driver or CUDA Toolkit.",
+    )
 
-    # install_driver_parser = subparsers.add_parser('install_driver', help='Install GPU driver.')
-    # install_cuda_parser = subparsers.add_parser('install_cuda', help='Install CUDA toolkit.')
-    # verify_driver_parser = subparsers.add_parser('verify_driver', help='Verify GPU driver installation.')
-    # verify_cuda_parser = subparsers.add_parser('verify_cuda', help='Verify CUDA toolkit installation.')
-    # uninstall_driver_parser = subparsers.add_parser('uninstall_driver', help='Uninstall GPU driver.')
-    # uninstall_cuda_parser = subparsers.add_parser('uninstall_cuda', help='Uninstall CUDA toolkit.')
-    # update_kernel = subparsers.add_parser('update_kernel', help='Update system kernel if an update is available.')
-
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if os.geteuid() != 0:
         print("This script needs to be run with root privileges!")
         sys.exit(1)
@@ -37,7 +58,7 @@ if __name__ == '__main__':
     os.chdir(config.INSTALLER_DIR)
     installer = get_installer()
 
-    if args.command == 'install_driver':
+    if args.command == "install_driver":
         installer.install_driver()
     elif args.command == "verify_driver":
         if installer.verify_driver(verbose=True):
@@ -49,4 +70,7 @@ if __name__ == '__main__':
     elif args.command == "install_cuda":
         installer.install_cuda()
     elif args.command == "verify_cuda":
-        installer.verify_cuda()
+        if installer.verify_cuda():
+            sys.exit(0)
+        else:
+            sys.exit(1)

--- a/linux/cuda_installer/config.py
+++ b/linux/cuda_installer/config.py
@@ -1,6 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pathlib
 
-INSTALLER_DIR = pathlib.Path('/opt/google/cuda-installer/')
+INSTALLER_DIR = pathlib.Path("/opt/google/cuda-installer/")
 try:
     INSTALLER_DIR.mkdir(parents=True, exist_ok=True)
 except PermissionError:
@@ -10,16 +24,26 @@ except PermissionError:
 K80_DRIVER_VERSION = "470.239.06"
 K80_DEVICE_CODE = "10de:102d"
 K80_DRIVER_URL = f"https://us.download.nvidia.com/tesla/{K80_DRIVER_VERSION}/NVIDIA-Linux-x86_64-{K80_DRIVER_VERSION}.run"
-K80_DRIVER_SHA256_SUM = "7d74caac140a0432d79ebe8e4330dc796f39ba7dd40b3fcd61df760181bf9ccc"
+K80_DRIVER_SHA256_SUM = (
+    "7d74caac140a0432d79ebe8e4330dc796f39ba7dd40b3fcd61df760181bf9ccc"
+)
 
 CUDA_TOOLKIT_URL = "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run"
-CUDA_TOOLKIT_SHA256_SUM = "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb"
+CUDA_TOOLKIT_SHA256_SUM = (
+    "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb"
+)
 
-CUDA_SAMPLES_TARGZ = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v12.4.1.tar.gz"
-CUDA_SAMPLES_SHA256_SUM = "01bb311cc8f802a0d243700e4abe6a2d402132c9d97ecf2c64f3fbb1006c304c"
+CUDA_SAMPLES_TARGZ = (
+    "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v12.4.1.tar.gz"
+)
+CUDA_SAMPLES_SHA256_SUM = (
+    "01bb311cc8f802a0d243700e4abe6a2d402132c9d97ecf2c64f3fbb1006c304c"
+)
 
 CUDA_PROFILE_FILENAME = pathlib.Path("/etc/profile.d/google_cuda_install.sh")
 CUDA_BIN_FOLDER = "/usr/local/cuda-12.4/bin"
 CUDA_LIB_FOLDER = "/usr/local/cuda-12.4/lib64"
 
-NVIDIA_PERSISTANCED_INSTALLER = "/usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2"
+NVIDIA_PERSISTANCED_INSTALLER = (
+    "/usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2"
+)

--- a/linux/cuda_installer/config.py
+++ b/linux/cuda_installer/config.py
@@ -22,4 +22,4 @@ CUDA_PROFILE_FILENAME = pathlib.Path("/etc/profile.d/google_cuda_install.sh")
 CUDA_BIN_FOLDER = "/usr/local/cuda-12.4/bin"
 CUDA_LIB_FOLDER = "/usr/local/cuda-12.4/lib64"
 
-NVIDIA_PERSISTANCED_INSTALLER = "/usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2"
+NVIDIA_PERSISTANCED_INSTALLER = "/usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2"

--- a/linux/cuda_installer/config.py
+++ b/linux/cuda_installer/config.py
@@ -1,0 +1,25 @@
+import pathlib
+
+INSTALLER_DIR = pathlib.Path('/opt/google/cuda-installer/')
+try:
+    INSTALLER_DIR.mkdir(parents=True, exist_ok=True)
+except PermissionError:
+    pass
+
+
+K80_DRIVER_VERSION = "470.239.06"
+K80_DEVICE_CODE = "10de:102d"
+K80_DRIVER_URL = f"https://us.download.nvidia.com/tesla/{K80_DRIVER_VERSION}/NVIDIA-Linux-x86_64-{K80_DRIVER_VERSION}.run"
+K80_DRIVER_SHA256_SUM = "7d74caac140a0432d79ebe8e4330dc796f39ba7dd40b3fcd61df760181bf9ccc"
+
+CUDA_TOOLKIT_URL = "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run"
+CUDA_TOOLKIT_SHA256_SUM = "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb"
+
+CUDA_SAMPLES_TARGZ = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v12.4.1.tar.gz"
+CUDA_SAMPLES_SHA256_SUM = "01bb311cc8f802a0d243700e4abe6a2d402132c9d97ecf2c64f3fbb1006c304c"
+
+CUDA_PROFILE_FILENAME = pathlib.Path("/etc/profile.d/google_cuda_install.sh")
+CUDA_BIN_FOLDER = "/usr/local/cuda-12.4/bin"
+CUDA_LIB_FOLDER = "/usr/local/cuda-12.4/lib64"
+
+NVIDIA_PERSISTANCED_INSTALLER = "/usr/share/doc/NVIDIA_GLX-1.0/sample/nvidia-persistenced-init.tar.bz2"

--- a/linux/cuda_installer/decorators.py
+++ b/linux/cuda_installer/decorators.py
@@ -1,0 +1,28 @@
+import pathlib
+from datetime import datetime
+
+from config import INSTALLER_DIR
+from logger import logger
+
+
+def checkpoint_decorator(file_name: str, skip_message: str):
+    from os_installers import RebootRequired
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            if pathlib.Path(INSTALLER_DIR / file_name).exists():
+                logger.info(skip_message)
+                return
+            try:
+                func(*args, **kwargs)
+            except RebootRequired:
+                reboot_required = True
+            else:
+                reboot_required = False
+            with pathlib.Path(INSTALLER_DIR / file_name).open(mode='w') as flag:
+                flag.write(str(datetime.now()))
+                flag.flush()
+            if reboot_required:
+                raise RebootRequired
+        return wrapper
+    return decorator

--- a/linux/cuda_installer/decorators.py
+++ b/linux/cuda_installer/decorators.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pathlib
 from datetime import datetime
 
@@ -19,10 +33,12 @@ def checkpoint_decorator(file_name: str, skip_message: str):
                 reboot_required = True
             else:
                 reboot_required = False
-            with pathlib.Path(INSTALLER_DIR / file_name).open(mode='w') as flag:
+            with pathlib.Path(INSTALLER_DIR / file_name).open(mode="w") as flag:
                 flag.write(str(datetime.now()))
                 flag.flush()
             if reboot_required:
                 raise RebootRequired
+
         return wrapper
+
     return decorator

--- a/linux/cuda_installer/logger.py
+++ b/linux/cuda_installer/logger.py
@@ -1,0 +1,23 @@
+import logging
+import logging.handlers
+import sys
+
+from config import INSTALLER_DIR
+
+logger = logging.getLogger('GoogleCUDAInstaller')
+_file_handler = logging.FileHandler(INSTALLER_DIR / 'installer.log', mode='a')
+_file_handler.level = logging.DEBUG
+logger.addHandler(_file_handler)
+_sys_handler = logging.handlers.SysLogHandler('/dev/log', facility=logging.handlers.SysLogHandler.LOG_LOCAL0)
+_sys_handler.ident = "[GoogleCUDAInstaller] "
+_sys_handler.level = logging.INFO
+logger.addHandler(_sys_handler)
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.level = logging.INFO
+logger.addHandler(stdout_handler)
+logger.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter("[%(asctime)s] %(levelname)s - %(message)s")
+_file_handler.setFormatter(formatter)
+
+__all__ = ['logger']

--- a/linux/cuda_installer/logger.py
+++ b/linux/cuda_installer/logger.py
@@ -1,14 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import logging.handlers
 import sys
 
 from config import INSTALLER_DIR
 
-logger = logging.getLogger('GoogleCUDAInstaller')
-_file_handler = logging.FileHandler(INSTALLER_DIR / 'installer.log', mode='a')
+
+logger = logging.getLogger("GoogleCUDAInstaller")
+_file_handler = logging.FileHandler(INSTALLER_DIR / "installer.log", mode="a")
 _file_handler.level = logging.DEBUG
 logger.addHandler(_file_handler)
-_sys_handler = logging.handlers.SysLogHandler('/dev/log', facility=logging.handlers.SysLogHandler.LOG_LOCAL0)
+_sys_handler = logging.handlers.SysLogHandler(
+    "/dev/log", facility=logging.handlers.SysLogHandler.LOG_LOCAL0
+)
 _sys_handler.ident = "[GoogleCUDAInstaller] "
 _sys_handler.level = logging.INFO
 logger.addHandler(_sys_handler)
@@ -20,4 +37,4 @@ logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter("[%(asctime)s] %(levelname)s - %(message)s")
 _file_handler.setFormatter(formatter)
 
-__all__ = ['logger']
+__all__ = ["logger"]

--- a/linux/cuda_installer/os_installers/__init__.py
+++ b/linux/cuda_installer/os_installers/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import abc
 import os
 import pathlib
@@ -9,13 +23,22 @@ import sys
 import tempfile
 import urllib.parse
 from contextlib import contextmanager
-from datetime import datetime
 from enum import Enum, auto
 from typing import Optional, Union
 
-from config import K80_DRIVER_URL, CUDA_TOOLKIT_URL, CUDA_TOOLKIT_SHA256_SUM, K80_DRIVER_SHA256_SUM, \
-    K80_DEVICE_CODE, CUDA_PROFILE_FILENAME, CUDA_BIN_FOLDER, CUDA_LIB_FOLDER, NVIDIA_PERSISTANCED_INSTALLER, \
-    CUDA_SAMPLES_TARGZ, CUDA_SAMPLES_SHA256_SUM
+from config import (
+    K80_DRIVER_URL,
+    CUDA_TOOLKIT_URL,
+    CUDA_TOOLKIT_SHA256_SUM,
+    K80_DRIVER_SHA256_SUM,
+    K80_DEVICE_CODE,
+    CUDA_PROFILE_FILENAME,
+    CUDA_BIN_FOLDER,
+    CUDA_LIB_FOLDER,
+    NVIDIA_PERSISTANCED_INSTALLER,
+    CUDA_SAMPLES_TARGZ,
+    CUDA_SAMPLES_SHA256_SUM,
+)
 from decorators import checkpoint_decorator
 from logger import logger
 
@@ -36,6 +59,9 @@ class System(Enum):
 
 @contextmanager
 def chdir(path: Union[pathlib.Path, str]):
+    """
+    Switch the current working directory for a while. Restore the previous one on context exit.
+    """
     prev = os.getcwd()
     try:
         os.chdir(path)
@@ -45,8 +71,13 @@ def chdir(path: Union[pathlib.Path, str]):
 
 
 class LinuxInstaller(metaclass=abc.ABCMeta):
+    """
+    Handles the installation process for both driver and CUDA toolkit. Needs to have couple of methods implemented
+    in child classes, but contains most of the required logic.
+    """
+
     def __init__(self):
-        self.kernel_version = self.run('uname -r', silent=True).stdout
+        self.kernel_version = self.run("uname -r", silent=True).stdout
         self.device_code = self.detect_gpu_device()
         self._file_download_verified = set()
 
@@ -72,6 +103,15 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         pass
 
     def install_driver(self):
+        """
+        Downloads the installation package and installs the driver. It also handles installation of
+        drive prerequisites and will trigger a reboot on first run, when those prerequisites are installed.
+
+        On second run, it will proceed to download proper installer and install the driver. When it's done, `nvidia-smi`
+        should be available in the system and the drivers are installed.
+
+        It also triggers kernel packages lock in the system, so the driver is not broken by auto-updates.
+        """
         if self.verify_driver():
             logger.info("GPU driver already installed.")
             return
@@ -98,9 +138,15 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
             self.lock_kernel_updates()
             logger.info("GPU driver installation completed!")
         else:
-            logger.error("Something went wrong with driver installation. The installation failed :(")
+            logger.error(
+                "Something went wrong with driver installation. The installation failed :("
+            )
 
     def uninstall_driver(self):
+        """
+        Uses the Nvidia installers to execute driver uninstallation. It will also unlock the kernel updates in the
+        system.
+        """
         if not self.verify_driver():
             logger.info("GPU driver not found.")
             return
@@ -109,9 +155,13 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
                 installer_path = self.download_k80_driver_installer()
             else:
                 installer_path = self.download_cuda_toolkit_installer()
-                logger.info("Extracting NVIDIA driver installer, to complete uninstallation...")
+                logger.info(
+                    "Extracting NVIDIA driver installer, to complete uninstallation..."
+                )
                 self.run(f"sh {installer_path} --extract={temp_dir}", check=True)
-                installer_path = pathlib.Path(f"{temp_dir}/NVIDIA-Linux-x86_64-550.54.15.run")
+                installer_path = pathlib.Path(
+                    f"{temp_dir}/NVIDIA-Linux-x86_64-550.54.15.run"
+                )
 
             logger.info("Starting uninstallation...")
             self.run(f"sh {installer_path} -s --uninstall", check=True)
@@ -121,7 +171,7 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
     def verify_driver(self, verbose: bool = False) -> bool:
         """
         Checks if the driver is already installed by calling the `nvidia-smi` binary.
-        If it's available, that means the driver is already installed.
+        If it's available and doesn't produce errors, that means the driver is already installed.
         """
         process = self.run("which nvidia-smi", check=False, silent=True)
         if process.returncode != 0:
@@ -134,14 +184,22 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
             print(f"nvidia-smi -L output: {process2.stdout} {process2.stderr}")
         return success
 
-    @checkpoint_decorator("cuda_installation", "CUDA toolkit already marked as installed.")
+    @checkpoint_decorator(
+        "cuda_installation", "CUDA toolkit already marked as installed."
+    )
     def _install_cuda(self):
+        """
+        This is the method to install the CUDA Toolkit. It will install the toolkit and execute post-installation
+        configuration in the operating system, to make it available for all users.
+        """
         if self.device_code == K80_DEVICE_CODE:
             logger.info("CUDA installation is not supported for K80 GPUs.")
             return
         if not self.verify_driver():
-            logger.info("CUDA installation requires GPU driver to be installed first. "
-                        "Attempting to install GPU driver now.")
+            logger.info(
+                "CUDA installation requires GPU driver to be installed first. "
+                "Attempting to install GPU driver now."
+            )
             self.install_driver()
 
         installer_path = self.download_cuda_toolkit_installer()
@@ -166,22 +224,36 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         * set environment variables
         * make persistent changes to environment variables
         * configure nvidia-persistanced to auto-start (if exists)
+
+        More info: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions
         """
         os.environ["PATH"] = f"{CUDA_BIN_FOLDER}:{os.environ['PATH']}"
         if "LD_LIBRARY_PATH" in os.environ:
-            os.environ["LD_LIBRARY_PATH"] = f"{CUDA_LIB_FOLDER}:{os.environ['LD_LIBRARY_PATH']}"
+            os.environ["LD_LIBRARY_PATH"] = (
+                f"{CUDA_LIB_FOLDER}:{os.environ['LD_LIBRARY_PATH']}"
+            )
         else:
             os.environ["LD_LIBRARY_PATH"] = CUDA_LIB_FOLDER
 
         with CUDA_PROFILE_FILENAME.open("w") as profile:
-            profile.write("# Configuring CUDA toolkit. File created by Google CUDA installation manager.\n")
+            profile.write(
+                "# Configuring CUDA toolkit. File created by Google CUDA installation manager.\n"
+            )
             profile.write("export PATH=" + CUDA_BIN_FOLDER + "${PATH:+:${PATH}}\n")
-            profile.write("export LD_LIBRARY_PATH=" + CUDA_LIB_FOLDER + "${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}\n")
+            profile.write(
+                "export LD_LIBRARY_PATH="
+                + CUDA_LIB_FOLDER
+                + "${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}\n"
+            )
 
         self.configure_persistanced_service()
 
     def configure_persistanced_service(self):
-        if not pathlib.Path('/usr/bin/nvidia-persistenced').exists():
+        """
+        Configures the nvidia-persistenced daemon to auto-start. It creates a service to be controlled using
+        `systemctl`.
+        """
+        if not pathlib.Path("/usr/bin/nvidia-persistenced").exists():
             return
 
         if not pathlib.Path(NVIDIA_PERSISTANCED_INSTALLER).exists():
@@ -196,33 +268,52 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
 
     def verify_cuda(self) -> bool:
         """
-        Make sure that CUDA is properly installed by compiling and executing CUDA code samples.
+        Make sure that CUDA Toolkit is properly installed by compiling and executing CUDA code samples.
         """
         logger.info("Verifying CUDA installation...")
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_dir = pathlib.Path(temp_dir)
             with chdir(temp_dir):
-                logger.info(f"Using {temp_dir} to download, build and execute code samples.")
-                samples_tar = self.download_file(CUDA_SAMPLES_TARGZ, CUDA_SAMPLES_SHA256_SUM)
+                logger.info(
+                    f"Using {temp_dir} to download, build and execute code samples."
+                )
+                samples_tar = self.download_file(
+                    CUDA_SAMPLES_TARGZ, CUDA_SAMPLES_SHA256_SUM
+                )
                 self.run(f"tar -xf {samples_tar.name}")
-                with chdir(temp_dir / "cuda-samples-12.4.1/Samples/1_Utilities/deviceQuery"):
+                with chdir(
+                    temp_dir / "cuda-samples-12.4.1/Samples/1_Utilities/deviceQuery"
+                ):
                     self.run("make", check=True)
                     dev_query = self.run("./deviceQuery", check=True)
                     if "Result = PASS" not in dev_query.stdout:
-                        logger.error("Cuda Toolkit verification failed. DeviceQuery sample failed.")
+                        logger.error(
+                            "Cuda Toolkit verification failed. DeviceQuery sample failed."
+                        )
                         return False
-                with chdir(temp_dir / "cuda-samples-12.4.1/Samples/1_Utilities/bandwidthTest"):
+                with chdir(
+                    temp_dir / "cuda-samples-12.4.1/Samples/1_Utilities/bandwidthTest"
+                ):
                     self.run("make", check=True)
                     bandwidth = self.run("./bandwidthTest", check=True)
                     if "Result = PASS" not in bandwidth.stdout:
-                        logger.error("Cuda Toolkit verification failed. BandwidthTest sample failed.")
+                        logger.error(
+                            "Cuda Toolkit verification failed. BandwidthTest sample failed."
+                        )
                         return False
         logger.info("Cuda Toolkit verification completed!")
         return True
 
     @staticmethod
-    def run(command: str, check=True, input=None, cwd=None, silent=False, environment=None,
-            retries=0) -> subprocess.CompletedProcess:
+    def run(
+        command: str,
+        check=True,
+        input=None,
+        cwd=None,
+        silent=False,
+        environment=None,
+        retries=0,
+    ) -> subprocess.CompletedProcess:
         """
         Runs a provided command, streaming its output to the log files.
 
@@ -247,12 +338,14 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         while try_count <= retries:
             stdout.clear()
             stderr.clear()
-            proc = subprocess.Popen(shlex.split(command),
-                                    stderr=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stdin=subprocess.PIPE if input else None,
-                                    cwd=cwd,
-                                    env=environment)
+            proc = subprocess.Popen(
+                shlex.split(command),
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE if input else None,
+                cwd=cwd,
+                env=environment,
+            )
             os.set_blocking(proc.stdout.fileno(), False)
             os.set_blocking(proc.stderr.fileno(), False)
             if input is not None:
@@ -288,7 +381,9 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         if check and proc.returncode:
             raise subprocess.SubprocessError("Command exited with non-zero code")
 
-        return subprocess.CompletedProcess(command, proc.returncode, stdout="\n".join(stdout), stderr="\n".join(stderr))
+        return subprocess.CompletedProcess(
+            command, proc.returncode, stdout="\n".join(stdout), stderr="\n".join(stderr)
+        )
 
     @classmethod
     def check_gpu_present(cls) -> bool:
@@ -296,7 +391,7 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         Checks in `lspci` if there's an NVIDIA device present in the system.
         """
         lspci = cls.run("lspci")
-        return 'nvidia' in lspci.stdout.lower()
+        return "nvidia" in lspci.stdout.lower()
 
     @classmethod
     def check_driver_installed(cls) -> bool:
@@ -318,18 +413,22 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         if sys.version_info.major == 3 and sys.version_info.minor >= 6:
             return
         version = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
-        raise RuntimeError("Unsupported Python version {}. "
-                           "Supported versions: 3.6 - 3.12".format(version))
+        raise RuntimeError(
+            "Unsupported Python version {}. "
+            "Supported versions: 3.6 - 3.12".format(version)
+        )
 
     @classmethod
     def reboot(cls):
         """
         Reboots the system.
         """
-        logger.info("The system needs to be rebooted to complete the installation process. "
-                    "The process will be continued after the reboot.")
+        logger.info(
+            "The system needs to be rebooted to complete the installation process. "
+            "The process will be continued after the reboot."
+        )
         logger.info("Rebooting now.")
-        cls.run("reboot")
+        cls.run("reboot now")
         sys.exit(0)
 
     @classmethod
@@ -337,7 +436,7 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         """
         Check if there is an NVIDIA GPU device attached and return its device code.
         """
-        lspci = cls.run('lspci -n', silent=True)
+        lspci = cls.run("lspci -n", silent=True)
         output = lspci.stdout
         dev_re = re.compile(r"10de:[\w\d]{4}")
         for line in output.splitlines():
@@ -356,7 +455,14 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
         return self.download_file(K80_DRIVER_URL, K80_DRIVER_SHA256_SUM)
 
     def download_file(self, url: str, sha256sum: str) -> pathlib.Path:
-        filename = urllib.parse.urlparse(url).path.split('/')[-1]
+        """
+        Uses `curl` to download a file pointed by url. It will also execute `sha256sum` on the downloaded file
+        to verify if it's matching with the expected hash.
+
+        It also keeps track of files already downloaded and checked, so that it doesn't waste time with repeating the
+        download or check.
+        """
+        filename = urllib.parse.urlparse(url).path.split("/")[-1]
         file_path = pathlib.Path(filename)
 
         if file_path.exists() and url in self._file_download_verified:
@@ -367,8 +473,10 @@ class LinuxInstaller(metaclass=abc.ABCMeta):
 
         checksum = self.run(f"sha256sum {file_path}").stdout.strip().split()[0]
         if checksum != sha256sum:
-            raise RuntimeError(f"The installer file checksum does not match. Won't continue installation."
-                               f"Try deleting {file_path.absolute()} and trying again.")
+            raise RuntimeError(
+                f"The installer file checksum does not match. Won't continue installation."
+                f"Try deleting {file_path.absolute()} and trying again."
+            )
         self._file_download_verified.add(url)
         return file_path
 
@@ -378,39 +486,45 @@ def _detect_linux_distro() -> (System, str):
     Checks the /etc/os-release file to figure out what distribution of OS
     we're running.
     """
-    with open('/etc/os-release') as os_release:
-        lines = [line.strip() for line in os_release.readlines() if line.strip() != '']
-        info = {k: v.strip("'\"") for k, v in (line.split('=', maxsplit=1) for line in lines)}
+    with open("/etc/os-release") as os_release:
+        lines = [line.strip() for line in os_release.readlines() if line.strip() != ""]
+        info = {
+            k: v.strip("'\"")
+            for k, v in (line.split("=", maxsplit=1) for line in lines)
+        }
 
-    name = info['NAME']
+    name = info["NAME"]
 
     if name.startswith("Debian"):
         system = System.Debian
-        version = info['VERSION'].split()[0]  # 11 (rodete) -> 11
+        version = info["VERSION"].split()[0]  # 11 (rodete) -> 11
     elif name.startswith("CentOS"):
         system = System.CentOS
-        version = info['VERSION_ID']  # 8
+        version = info["VERSION_ID"]  # 8
     elif name.startswith("Rocky"):
         system = System.Rocky
-        version = info['VERSION_ID']  # 8.4
+        version = info["VERSION_ID"]  # 8.4
     elif name.startswith("Ubuntu"):
         system = System.Ubuntu
-        version = info['VERSION_ID']  # 20.04
+        version = info["VERSION_ID"]  # 20.04
     elif name.startswith("SLES"):
         system = System.SUSE
-        version = info['VERSION_ID']  # 15.3
+        version = info["VERSION_ID"]  # 15.3
     elif name.startswith("Red Hat"):
         system = System.RHEL
-        version = info['VERSION_ID']  # 8.4
+        version = info["VERSION_ID"]  # 8.4
     elif name.startswith("Fedora"):
         system = System.Fedora
-        version = info['VERSION_ID']  # 34
+        version = info["VERSION_ID"]  # 34
     else:
         raise RuntimeError("Unrecognized operating system.")
     return system, version
 
 
 def get_installer() -> LinuxInstaller:
+    """
+    Retrieve an Installer instance appropriate for the hosting operating system.
+    """
     system, version = _detect_linux_distro()
 
     from os_installers.debian import DebianInstaller

--- a/linux/cuda_installer/os_installers/__init__.py
+++ b/linux/cuda_installer/os_installers/__init__.py
@@ -1,0 +1,411 @@
+import abc
+import os
+import pathlib
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+from contextlib import contextmanager
+from datetime import datetime
+from enum import Enum, auto
+from typing import Optional, Union
+
+from config import K80_DRIVER_URL, CUDA_TOOLKIT_URL, CUDA_TOOLKIT_SHA256_SUM, K80_DRIVER_SHA256_SUM, \
+    K80_DEVICE_CODE, CUDA_PROFILE_FILENAME, CUDA_BIN_FOLDER, CUDA_LIB_FOLDER, NVIDIA_PERSISTANCED_INSTALLER, \
+    CUDA_SAMPLES_TARGZ, CUDA_SAMPLES_SHA256_SUM
+from decorators import checkpoint_decorator
+from logger import logger
+
+
+class RebootRequired(RuntimeError):
+    pass
+
+
+class System(Enum):
+    CentOS = auto()
+    Debian = auto()
+    Fedora = auto()
+    RHEL = auto()
+    Rocky = auto()
+    SUSE = auto()
+    Ubuntu = auto()
+
+
+@contextmanager
+def chdir(path: Union[pathlib.Path, str]):
+    prev = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(prev)
+
+
+class LinuxInstaller(metaclass=abc.ABCMeta):
+    def __init__(self):
+        self.kernel_version = self.run('uname -r', silent=True).stdout
+        self.device_code = self.detect_gpu_device()
+        self._file_download_verified = set()
+
+    @abc.abstractmethod
+    def _install_prerequisites(self):
+        """
+        Update kernel to the newest version and install all required packages for the NVIDIA drivers to be installed.
+        """
+        pass
+
+    @abc.abstractmethod
+    def lock_kernel_updates(self):
+        """
+        Make sure that drivers aren't broken by an automatic kernel update.
+        """
+        pass
+
+    @abc.abstractmethod
+    def unlock_kernel_updates(self):
+        """
+        Allows the kernel related packages to be upgraded.
+        """
+        pass
+
+    def install_driver(self):
+        if self.verify_driver():
+            logger.info("GPU driver already installed.")
+            return
+
+        if self.device_code == K80_DEVICE_CODE:
+            installer_path = self.download_k80_driver_installer()
+        else:
+            installer_path = self.download_cuda_toolkit_installer()
+
+        logger.info("Installing prerequisite packages and updating kernel...")
+        try:
+            self._install_prerequisites()
+        except RebootRequired:
+            self.reboot()
+
+        if self.device_code == K80_DEVICE_CODE:
+            logger.info("Installing GPU drivers for K80...")
+            self.run(f"sh {installer_path} -s", check=True)
+        else:
+            logger.info("Installing GPU drivers for your device...")
+            self.run(f"sh {installer_path} --silent --driver", check=True)
+
+        if self.verify_driver():
+            self.lock_kernel_updates()
+            logger.info("GPU driver installation completed!")
+        else:
+            logger.error("Something went wrong with driver installation. The installation failed :(")
+
+    def uninstall_driver(self):
+        if not self.verify_driver():
+            logger.info("GPU driver not found.")
+            return
+        with tempfile.TemporaryDirectory() as temp_dir:
+            if self.device_code == K80_DEVICE_CODE:
+                installer_path = self.download_k80_driver_installer()
+            else:
+                installer_path = self.download_cuda_toolkit_installer()
+                logger.info("Extracting NVIDIA driver installer, to complete uninstallation...")
+                self.run(f"sh {installer_path} --extract={temp_dir}", check=True)
+                installer_path = pathlib.Path(f"{temp_dir}/NVIDIA-Linux-x86_64-550.54.15.run")
+
+            logger.info("Starting uninstallation...")
+            self.run(f"sh {installer_path} -s --uninstall", check=True)
+            logger.info("Uninstallation completed!")
+        self.unlock_kernel_updates()
+
+    def verify_driver(self, verbose: bool = False) -> bool:
+        """
+        Checks if the driver is already installed by calling the `nvidia-smi` binary.
+        If it's available, that means the driver is already installed.
+        """
+        process = self.run("which nvidia-smi", check=False, silent=True)
+        if process.returncode != 0:
+            if verbose:
+                print("Couldn't find nvidia-smi, the driver is not installed.")
+            return False
+        process2 = self.run("nvidia-smi -L", check=False, silent=True)
+        success = process2.returncode == 0 and "UUID" in process2.stdout
+        if verbose:
+            print(f"nvidia-smi -L output: {process2.stdout} {process2.stderr}")
+        return success
+
+    @checkpoint_decorator("cuda_installation", "CUDA toolkit already marked as installed.")
+    def install_cuda(self):
+        if self.device_code == K80_DEVICE_CODE:
+            logger.info("CUDA installation is not supported for K80 GPUs.")
+            return
+        if not self.verify_driver():
+            logger.info("CUDA installation requires GPU driver to be installed first. "
+                        "Attempting to install GPU driver now.")
+            self.install_driver()
+
+        installer_path = self.download_cuda_toolkit_installer()
+
+        logger.info("Installing CUDA toolkit...")
+        self.run(f"sh {installer_path} --silent --toolkit", check=True)
+        logger.info("CUDA toolkit installation completed!")
+        logger.info("Executing post-installation actions...")
+        self.cuda_postinstallation_actions()
+        logger.info("CUDA post-installation actions completed!")
+        raise RebootRequired
+
+    def cuda_postinstallation_actions(self):
+        """
+        Perform required and suggested post-installation actions:
+        * set environment variables
+        * make persistent changes to environment variables
+        * configure nvidia-persistanced to auto-start (if exists)
+        """
+        os.environ["PATH"] = f"{CUDA_BIN_FOLDER}:{os.environ['PATH']}"
+        if "LD_LIBRARY_PATH" in os.environ:
+            os.environ["LD_LIBRARY_PATH"] = f"{CUDA_LIB_FOLDER}:{os.environ['LD_LIBRARY_PATH']}"
+        else:
+            os.environ["LD_LIBRARY_PATH"] = CUDA_LIB_FOLDER
+
+        with CUDA_PROFILE_FILENAME.open("w") as profile:
+            profile.write("# Configuring CUDA toolkit. File created by Google CUDA installation manager.\n")
+            profile.write("export PATH=" + CUDA_BIN_FOLDER + "${PATH:+:${PATH}}\n")
+            profile.write("export LD_LIBRARY_PATH=" + CUDA_LIB_FOLDER + "${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}\n")
+
+        self.configure_persistanced_service()
+
+    def configure_persistanced_service(self):
+        if not pathlib.Path('/usr/bin/nvidia-persistenced').exists():
+            return
+
+        if not pathlib.Path(NVIDIA_PERSISTANCED_INSTALLER).exists():
+            return
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            shutil.copy(NVIDIA_PERSISTANCED_INSTALLER, temp_dir + "/installer.tar.bz2")
+            with chdir(temp_dir):
+                self.run("tar -xf installer.tar.bz2", silent=True)
+                logger.info("Executing nvidia-persistenced installer...")
+                self.run("sh nvidia-persistenced-init/install.sh", check=True)
+
+    def verify_cuda(self) -> bool:
+        """
+        Make sure that CUDA is properly installed by compiling and executing CUDA code samples.
+        """
+        logger.info("Verifying CUDA installation...")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with chdir(temp_dir):
+                logger.info(f"Using {temp_dir} to download, build and execute code samples.")
+                samples_tar = self.download_file(CUDA_SAMPLES_TARGZ, CUDA_SAMPLES_SHA256_SUM)
+
+
+        return True
+
+    @staticmethod
+    def run(command: str, check=True, input=None, cwd=None, silent=False, environment=None,
+            retries=0) -> subprocess.CompletedProcess:
+        """
+        Runs a provided command, streaming its output to the log files.
+
+        :param command: A command to be executed, as a single string.
+        :param check: If true, will throw exception on failure (exit code != 0)
+        :param input: Input for the executed command.
+        :param cwd: Directory in which to execute the command.
+        :param silent: If set to True, the output of command won't be logged or printed.
+        :param environment: A set of environment variable for the process to use. If None, the current env is inherited.
+        :param retries: How many times should the command be repeated if it exits with non-zero code.
+
+        :return: CompletedProcess instance - the result of the command execution.
+        """
+        if not silent:
+            logger.info(f"Executing: {command}")
+
+        try_count = 0
+        stdout = []
+        stderr = []
+        proc = None
+
+        while try_count <= retries:
+            stdout.clear()
+            stderr.clear()
+            proc = subprocess.Popen(shlex.split(command),
+                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stdin=subprocess.PIPE if input else None,
+                                    cwd=cwd,
+                                    env=environment)
+            os.set_blocking(proc.stdout.fileno(), False)
+            os.set_blocking(proc.stderr.fileno(), False)
+            if input is not None:
+                proc.stdin.write(input.encode())
+                proc.stdin.close()
+
+            def capture_comms():
+                for line in proc.stdout.readlines():
+                    if not silent:
+                        logger.info(line.decode().strip())
+                    stdout.append(line.decode().strip())
+                for line in proc.stderr.readlines():
+                    if not silent:
+                        logger.warning(line.decode().strip())
+                    stdout.append(line.decode().strip())
+
+            while proc.poll() is None:
+                # While the process is running, we capture the output
+                capture_comms()
+                try:
+                    proc.wait(0.1)
+                except subprocess.TimeoutExpired:
+                    continue
+            # When the process is finished, we need to capture any output left in buffers
+            capture_comms()
+
+            if proc.returncode == 0:
+                break
+            else:
+                try_count += 1
+                continue
+
+        if check and proc.returncode:
+            raise subprocess.SubprocessError("Command exited with non-zero code")
+
+        return subprocess.CompletedProcess(command, proc.returncode, stdout="\n".join(stdout), stderr="\n".join(stderr))
+
+    @classmethod
+    def check_gpu_present(cls) -> bool:
+        """
+        Checks in `lspci` if there's an NVIDIA device present in the system.
+        """
+        lspci = cls.run("lspci")
+        return 'nvidia' in lspci.stdout.lower()
+
+    @classmethod
+    def check_driver_installed(cls) -> bool:
+        """
+        Checks if the driver is already installed by calling the `nvidia-smi` binary.
+        If it's available, that means the driver is already installed.
+        """
+        process = cls.run("which nvidia-smi", check=False)
+        if process.returncode != 0:
+            return False
+        process2 = cls.run("nvidia-smi", check=False)
+        return process2.returncode == 0
+
+    @staticmethod
+    def check_python_version():
+        """
+        Makes sure that the script is run with Python 3.6 or newer.
+        """
+        if sys.version_info.major == 3 and sys.version_info.minor >= 6:
+            return
+        version = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
+        raise RuntimeError("Unsupported Python version {}. "
+                           "Supported versions: 3.6 - 3.12".format(version))
+
+    @classmethod
+    def reboot(cls):
+        """
+        Reboots the system.
+        """
+        logger.info("The system needs to be rebooted to complete the installation process. "
+                    "The process will be continued after the reboot.")
+        logger.info("Rebooting now.")
+        cls.run("reboot")
+        sys.exit(0)
+
+    @classmethod
+    def detect_gpu_device(cls) -> Optional[str]:
+        """
+        Check if there is an NVIDIA GPU device attached and return its device code.
+        """
+        lspci = cls.run('lspci -n', silent=True)
+        output = lspci.stdout
+        dev_re = re.compile(r"10de:[\w\d]{4}")
+        for line in output.splitlines():
+            dev_code = dev_re.findall(line)
+            if dev_code:
+                return dev_code[0]
+        else:
+            return None
+
+    def download_cuda_toolkit_installer(self) -> pathlib.Path:
+        logger.info("Downloading CUDA installation kit...")
+        return self.download_file(CUDA_TOOLKIT_URL, CUDA_TOOLKIT_SHA256_SUM)
+
+    def download_k80_driver_installer(self) -> pathlib.Path:
+        logger.info("K80 GPU detected, downloading only the driver installer...")
+        return self.download_file(K80_DRIVER_URL, K80_DRIVER_SHA256_SUM)
+
+    def download_file(self, url: str, sha256sum: str) -> pathlib.Path:
+        filename = urllib.parse.urlparse(url).path.split('/')[-1]
+        file_path = pathlib.Path(filename)
+
+        if file_path.exists() and url in self._file_download_verified:
+            return file_path
+
+        if not file_path.exists():
+            self.run(f"curl -fSsl -O {url}")
+
+        checksum = self.run(f"sha256sum {file_path}").stdout.strip().split()[0]
+        if checksum != sha256sum:
+            raise RuntimeError(f"The installer file checksum does not match. Won't continue installation."
+                               f"Try deleting {file_path.absolute()} and trying again.")
+        self._file_download_verified.add(url)
+        return file_path
+
+
+def _detect_linux_distro() -> (System, str):
+    """
+    Checks the /etc/os-release file to figure out what distribution of OS
+    we're running.
+    """
+    with open('/etc/os-release') as os_release:
+        lines = [line.strip() for line in os_release.readlines() if line.strip() != '']
+        info = {k: v.strip("'\"") for k, v in (line.split('=', maxsplit=1) for line in lines)}
+
+    name = info['NAME']
+
+    if name.startswith("Debian"):
+        system = System.Debian
+        version = info['VERSION'].split()[0]  # 11 (rodete) -> 11
+    elif name.startswith("CentOS"):
+        system = System.CentOS
+        version = info['VERSION_ID']  # 8
+    elif name.startswith("Rocky"):
+        system = System.Rocky
+        version = info['VERSION_ID']  # 8.4
+    elif name.startswith("Ubuntu"):
+        system = System.Ubuntu
+        version = info['VERSION_ID']  # 20.04
+    elif name.startswith("SLES"):
+        system = System.SUSE
+        version = info['VERSION_ID']  # 15.3
+    elif name.startswith("Red Hat"):
+        system = System.RHEL
+        version = info['VERSION_ID']  # 8.4
+    elif name.startswith("Fedora"):
+        system = System.Fedora
+        version = info['VERSION_ID']  # 34
+    else:
+        raise RuntimeError("Unrecognized operating system.")
+    return system, version
+
+
+def get_installer() -> LinuxInstaller:
+    system, version = _detect_linux_distro()
+
+    from os_installers.debian import DebianInstaller
+    from os_installers.ubuntu import UbuntuInstaller
+    from os_installers.rhel import RHELInstaller
+    from os_installers.rocky import RockyInstaller
+
+    if system == System.Debian:
+        return DebianInstaller()
+    elif system == System.Ubuntu:
+        return UbuntuInstaller()
+    elif system == System.RHEL:
+        return RHELInstaller()
+    elif system == System.Rocky:
+        return RockyInstaller()
+    else:
+        raise NotImplementedError("Sorry, don't know how to install for this system.")

--- a/linux/cuda_installer/os_installers/debian.py
+++ b/linux/cuda_installer/os_installers/debian.py
@@ -57,14 +57,6 @@ class DebianInstaller(LinuxInstaller):
                  f"linux-headers-cloud-amd64"
                  )
 
-    def uninstall_driver(self):
-        pass
-
-    def uninstall_cuda(self):
-        pass
-
-    def verify_cuda(self):
-        pass
 
     def upgrade_kernel(self):
         # Update package: linux-image-cloud-amd64

--- a/linux/cuda_installer/os_installers/debian.py
+++ b/linux/cuda_installer/os_installers/debian.py
@@ -65,8 +65,8 @@ class DebianInstaller(LinuxInstaller):
         self.run(
             f"apt-mark hold "
             f"linux-image-{self.kernel_version} "
-            f"linux-headers-{self.kernel_version}"
-            f"linux-image-cloud-amd64"
+            f"linux-headers-{self.kernel_version} "
+            f"linux-image-cloud-amd64 "
             f"linux-headers-cloud-amd64"
         )
 
@@ -78,7 +78,7 @@ class DebianInstaller(LinuxInstaller):
         self.run(
             f"apt-mark unhold "
             f"linux-image-{self.kernel_version} "
-            f"linux-headers-{self.kernel_version}"
-            f"linux-image-cloud-amd64"
+            f"linux-headers-{self.kernel_version} "
+            f"linux-image-cloud-amd64 "
             f"linux-headers-cloud-amd64"
         )

--- a/linux/cuda_installer/os_installers/debian.py
+++ b/linux/cuda_installer/os_installers/debian.py
@@ -1,0 +1,72 @@
+import re
+
+from decorators import checkpoint_decorator
+from os_installers import LinuxInstaller, RebootRequired
+from logger import logger
+
+
+class DebianInstaller(LinuxInstaller):
+    KERNEL_IMAGE_PACKAGE = "linux-image-{version}"
+    KERNEL_VERSION_FORMAT = "{major}.{minor}.{patch}-{micro}-cloud-amd64"
+    KERNEL_HEADERS_PACKAGE = "linux-headers-{version}"
+    KERNEL_PACKAGE_REGEX = r"linux-image-{major}.{minor}.([\d]+)-([\d]+)-cloud-amd64"
+
+    @checkpoint_decorator("prerequisites", "System preparations already done.")
+    def _install_prerequisites(self):
+        """
+        Installs packages required for the proper driver installation on Debian.
+        """
+        self.run("apt-get update", silent=True)
+
+        major, minor, *_ = self.kernel_version.split(".")
+        kernel_package_regex = re.compile(self.KERNEL_PACKAGE_REGEX.format(major=major, minor=minor))
+
+        # Find the newest version of kernel to update to, but staying with the same major version
+        packages = self.run("apt-cache search linux-image").stdout
+        patch, micro = max(kernel_package_regex.findall(packages))
+
+        wanted_kernel_version = self.KERNEL_VERSION_FORMAT.format(major=major, minor=minor, patch=patch, micro=micro)
+        wanted_kernel_package = self.KERNEL_IMAGE_PACKAGE.format(version=wanted_kernel_version)
+        wanted_kernel_headers = self.KERNEL_HEADERS_PACKAGE.format(version=wanted_kernel_version)
+
+        self.run(f"apt-get install -y make gcc {wanted_kernel_package} {wanted_kernel_headers} "
+                 f"software-properties-common pciutils gcc make dkms")
+        raise RebootRequired
+
+    def lock_kernel_updates(self):
+        """
+        Marks kernel related packages, so they don't get auto-updated. This would cause the driver to stop working.
+        """
+        logger.info("Locking kernel updates...")
+        self.run(f"apt-mark hold "
+                 f"linux-image-{self.kernel_version} "
+                 f"linux-headers-{self.kernel_version}"
+                 f"linux-image-cloud-amd64"
+                 f"linux-headers-cloud-amd64"
+                 )
+
+    def unlock_kernel_updates(self):
+        """
+        Allows the kernel related packages to be upgraded.
+        """
+        logger.info("Unlocking kernel updates...")
+        self.run(f"apt-mark unhold "
+                 f"linux-image-{self.kernel_version} "
+                 f"linux-headers-{self.kernel_version}"
+                 f"linux-image-cloud-amd64"
+                 f"linux-headers-cloud-amd64"
+                 )
+
+    def uninstall_driver(self):
+        pass
+
+    def uninstall_cuda(self):
+        pass
+
+    def verify_cuda(self):
+        pass
+
+    def upgrade_kernel(self):
+        # Update package: linux-image-cloud-amd64
+        pass
+

--- a/linux/cuda_installer/os_installers/debian.py
+++ b/linux/cuda_installer/os_installers/debian.py
@@ -1,8 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
 from decorators import checkpoint_decorator
-from os_installers import LinuxInstaller, RebootRequired
 from logger import logger
+from os_installers import LinuxInstaller, RebootRequired
 
 
 class DebianInstaller(LinuxInstaller):
@@ -19,18 +33,28 @@ class DebianInstaller(LinuxInstaller):
         self.run("apt-get update", silent=True)
 
         major, minor, *_ = self.kernel_version.split(".")
-        kernel_package_regex = re.compile(self.KERNEL_PACKAGE_REGEX.format(major=major, minor=minor))
+        kernel_package_regex = re.compile(
+            self.KERNEL_PACKAGE_REGEX.format(major=major, minor=minor)
+        )
 
         # Find the newest version of kernel to update to, but staying with the same major version
         packages = self.run("apt-cache search linux-image").stdout
         patch, micro = max(kernel_package_regex.findall(packages))
 
-        wanted_kernel_version = self.KERNEL_VERSION_FORMAT.format(major=major, minor=minor, patch=patch, micro=micro)
-        wanted_kernel_package = self.KERNEL_IMAGE_PACKAGE.format(version=wanted_kernel_version)
-        wanted_kernel_headers = self.KERNEL_HEADERS_PACKAGE.format(version=wanted_kernel_version)
+        wanted_kernel_version = self.KERNEL_VERSION_FORMAT.format(
+            major=major, minor=minor, patch=patch, micro=micro
+        )
+        wanted_kernel_package = self.KERNEL_IMAGE_PACKAGE.format(
+            version=wanted_kernel_version
+        )
+        wanted_kernel_headers = self.KERNEL_HEADERS_PACKAGE.format(
+            version=wanted_kernel_version
+        )
 
-        self.run(f"apt-get install -y make gcc {wanted_kernel_package} {wanted_kernel_headers} "
-                 f"software-properties-common pciutils gcc make dkms")
+        self.run(
+            f"apt-get install -y make gcc {wanted_kernel_package} {wanted_kernel_headers} "
+            f"software-properties-common pciutils gcc make dkms"
+        )
         raise RebootRequired
 
     def lock_kernel_updates(self):
@@ -38,27 +62,23 @@ class DebianInstaller(LinuxInstaller):
         Marks kernel related packages, so they don't get auto-updated. This would cause the driver to stop working.
         """
         logger.info("Locking kernel updates...")
-        self.run(f"apt-mark hold "
-                 f"linux-image-{self.kernel_version} "
-                 f"linux-headers-{self.kernel_version}"
-                 f"linux-image-cloud-amd64"
-                 f"linux-headers-cloud-amd64"
-                 )
+        self.run(
+            f"apt-mark hold "
+            f"linux-image-{self.kernel_version} "
+            f"linux-headers-{self.kernel_version}"
+            f"linux-image-cloud-amd64"
+            f"linux-headers-cloud-amd64"
+        )
 
     def unlock_kernel_updates(self):
         """
         Allows the kernel related packages to be upgraded.
         """
         logger.info("Unlocking kernel updates...")
-        self.run(f"apt-mark unhold "
-                 f"linux-image-{self.kernel_version} "
-                 f"linux-headers-{self.kernel_version}"
-                 f"linux-image-cloud-amd64"
-                 f"linux-headers-cloud-amd64"
-                 )
-
-
-    def upgrade_kernel(self):
-        # Update package: linux-image-cloud-amd64
-        pass
-
+        self.run(
+            f"apt-mark unhold "
+            f"linux-image-{self.kernel_version} "
+            f"linux-headers-{self.kernel_version}"
+            f"linux-image-cloud-amd64"
+            f"linux-headers-cloud-amd64"
+        )

--- a/linux/cuda_installer/os_installers/dnf_system.py
+++ b/linux/cuda_installer/os_installers/dnf_system.py
@@ -1,0 +1,69 @@
+from os_installers import LinuxInstaller
+import abc
+from logger import logger
+import shutil
+import configparser
+
+
+class DNFSystemInstaller(LinuxInstaller, metaclass=abc.ABCMeta):
+    """
+    An abstract class providing implementation of DNF kernel locking methods.
+    """
+
+    def lock_kernel_updates(self):
+        """Make sure no kernel updates are installed."""
+        logger.info("Attempting to update /etc/dnf/dnf.conf to block kernel updates.")
+
+        conf_parser = configparser.ConfigParser()
+        conf_parser.read('/etc/dnf/dnf.conf')
+        if 'exclude' in conf_parser['main']:
+            value = conf_parser['main']['exclude']
+            if 'kernel*' in value:
+                logger.info("Kernel updates are already blocked in /etc/dnf/dnf.conf")
+                return
+            value = [s.strip() for s in value.split(',')]
+            value.append('kernel*')
+        else:
+            value = ['kernel*']
+        conf_parser['main']['exclude'] = ', '.join(value)
+
+        shutil.copyfile('/etc/dnf/dnf.conf', '/etc/dnf/dnf.conf_backup')
+        try:
+            with open('/etc/dnf/dnf.conf', mode='w') as dnf_conf_file:
+                conf_parser.write(dnf_conf_file)
+        except Exception as e:
+            logger.error("Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(e))
+            shutil.copyfile('/etc/dnf/dnf.conf_backup', '/etc/dnf/dnf.conf')
+            raise e
+        else:
+            logger.info("Kernel updates blocked by `exclude` entry in /etc/dnf/dnf.conf")
+
+    def unlock_kernel_updates(self):
+        """Remove `kernel*` from exclusion list in /etc/dnf/dnf.conf"""
+        logger.info("Attempting to update /etc/dnf/dnf.conf to unblock kernel updates.")
+
+        conf_parser = configparser.ConfigParser()
+        conf_parser.read('/etc/dnf/dnf.conf')
+        if 'exclude' not in conf_parser['main']:
+            logger.info("Kernel updates are not blocked in /etc/dnf/dnf.conf")
+            return
+
+        value = conf_parser['main']['exclude']
+        value = [s.strip() for s in value.split(',')]
+        if "kernel*" not in value:
+            logger.info("Kernel updates are not blocked in /etc/dnf/dnf.conf")
+            return
+        value.remove("kernel*")
+        conf_parser['main']['exclude'] = ', '.join(value)
+
+        shutil.copyfile('/etc/dnf/dnf.conf', '/etc/dnf/dnf.conf_backup')
+
+        try:
+            with open('/etc/dnf/dnf.conf', mode='w') as dnf_conf_file:
+                conf_parser.write(dnf_conf_file)
+        except Exception as e:
+            logger.error("Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(e))
+            shutil.copyfile('/etc/dnf/dnf.conf_backup', '/etc/dnf/dnf.conf')
+            raise e
+        else:
+            logger.info("Kernel updates unblocked in /etc/dnf/dnf.conf")

--- a/linux/cuda_installer/os_installers/dnf_system.py
+++ b/linux/cuda_installer/os_installers/dnf_system.py
@@ -1,8 +1,23 @@
-from os_installers import LinuxInstaller
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import abc
-from logger import logger
-import shutil
 import configparser
+import shutil
+
+from logger import logger
+from os_installers import LinuxInstaller
 
 
 class DNFSystemInstaller(LinuxInstaller, metaclass=abc.ABCMeta):
@@ -15,55 +30,65 @@ class DNFSystemInstaller(LinuxInstaller, metaclass=abc.ABCMeta):
         logger.info("Attempting to update /etc/dnf/dnf.conf to block kernel updates.")
 
         conf_parser = configparser.ConfigParser()
-        conf_parser.read('/etc/dnf/dnf.conf')
-        if 'exclude' in conf_parser['main']:
-            value = conf_parser['main']['exclude']
-            if 'kernel*' in value:
+        conf_parser.read("/etc/dnf/dnf.conf")
+        if "exclude" in conf_parser["main"]:
+            value = conf_parser["main"]["exclude"]
+            if "kernel*" in value:
                 logger.info("Kernel updates are already blocked in /etc/dnf/dnf.conf")
                 return
-            value = [s.strip() for s in value.split(',')]
-            value.append('kernel*')
+            value = [s.strip() for s in value.split(",")]
+            value.append("kernel*")
         else:
-            value = ['kernel*']
-        conf_parser['main']['exclude'] = ', '.join(value)
+            value = ["kernel*"]
+        conf_parser["main"]["exclude"] = ", ".join(value)
 
-        shutil.copyfile('/etc/dnf/dnf.conf', '/etc/dnf/dnf.conf_backup')
+        shutil.copyfile("/etc/dnf/dnf.conf", "/etc/dnf/dnf.conf_backup")
         try:
-            with open('/etc/dnf/dnf.conf', mode='w') as dnf_conf_file:
+            with open("/etc/dnf/dnf.conf", mode="w") as dnf_conf_file:
                 conf_parser.write(dnf_conf_file)
         except Exception as e:
-            logger.error("Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(e))
-            shutil.copyfile('/etc/dnf/dnf.conf_backup', '/etc/dnf/dnf.conf')
+            logger.error(
+                "Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(
+                    e
+                )
+            )
+            shutil.copyfile("/etc/dnf/dnf.conf_backup", "/etc/dnf/dnf.conf")
             raise e
         else:
-            logger.info("Kernel updates blocked by `exclude` entry in /etc/dnf/dnf.conf")
+            logger.info(
+                "Kernel updates blocked by `exclude` entry in /etc/dnf/dnf.conf"
+            )
 
     def unlock_kernel_updates(self):
         """Remove `kernel*` from exclusion list in /etc/dnf/dnf.conf"""
         logger.info("Attempting to update /etc/dnf/dnf.conf to unblock kernel updates.")
 
         conf_parser = configparser.ConfigParser()
-        conf_parser.read('/etc/dnf/dnf.conf')
-        if 'exclude' not in conf_parser['main']:
+        conf_parser.read("/etc/dnf/dnf.conf")
+        if "exclude" not in conf_parser["main"]:
             logger.info("Kernel updates are not blocked in /etc/dnf/dnf.conf")
             return
 
-        value = conf_parser['main']['exclude']
-        value = [s.strip() for s in value.split(',')]
+        value = conf_parser["main"]["exclude"]
+        value = [s.strip() for s in value.split(",")]
         if "kernel*" not in value:
             logger.info("Kernel updates are not blocked in /etc/dnf/dnf.conf")
             return
         value.remove("kernel*")
-        conf_parser['main']['exclude'] = ', '.join(value)
+        conf_parser["main"]["exclude"] = ", ".join(value)
 
-        shutil.copyfile('/etc/dnf/dnf.conf', '/etc/dnf/dnf.conf_backup')
+        shutil.copyfile("/etc/dnf/dnf.conf", "/etc/dnf/dnf.conf_backup")
 
         try:
-            with open('/etc/dnf/dnf.conf', mode='w') as dnf_conf_file:
+            with open("/etc/dnf/dnf.conf", mode="w") as dnf_conf_file:
                 conf_parser.write(dnf_conf_file)
         except Exception as e:
-            logger.error("Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(e))
-            shutil.copyfile('/etc/dnf/dnf.conf_backup', '/etc/dnf/dnf.conf')
+            logger.error(
+                "Failed to update /etc/dnf/dnf.conf due to {}. Restoring config file from backup.".format(
+                    e
+                )
+            )
+            shutil.copyfile("/etc/dnf/dnf.conf_backup", "/etc/dnf/dnf.conf")
             raise e
         else:
             logger.info("Kernel updates unblocked in /etc/dnf/dnf.conf")

--- a/linux/cuda_installer/os_installers/rhel.py
+++ b/linux/cuda_installer/os_installers/rhel.py
@@ -7,11 +7,5 @@ class RHELInstaller(DNFSystemInstaller):
 
     @checkpoint_decorator("prerequisites", "System preparations already done.")
     def _install_prerequisites(self):
-        self.run("dnf --refresh install -y kernel kernel-devel kernel-headers gcc gcc-c++ make")
+        self.run("dnf --refresh install -y kernel kernel-devel kernel-headers gcc gcc-c++ make bzip2")
         raise RebootRequired
-
-    def uninstall_cuda(self):
-        pass
-
-    def verify_cuda(self) -> bool:
-        pass

--- a/linux/cuda_installer/os_installers/rhel.py
+++ b/linux/cuda_installer/os_installers/rhel.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from decorators import checkpoint_decorator
 from os_installers import RebootRequired
 from os_installers.dnf_system import DNFSystemInstaller
@@ -7,5 +21,7 @@ class RHELInstaller(DNFSystemInstaller):
 
     @checkpoint_decorator("prerequisites", "System preparations already done.")
     def _install_prerequisites(self):
-        self.run("dnf --refresh install -y kernel kernel-devel kernel-headers gcc gcc-c++ make bzip2")
+        self.run(
+            "dnf --refresh install -y kernel kernel-devel kernel-headers gcc gcc-c++ make bzip2"
+        )
         raise RebootRequired

--- a/linux/cuda_installer/os_installers/rhel.py
+++ b/linux/cuda_installer/os_installers/rhel.py
@@ -1,0 +1,17 @@
+from decorators import checkpoint_decorator
+from os_installers import RebootRequired
+from os_installers.dnf_system import DNFSystemInstaller
+
+
+class RHELInstaller(DNFSystemInstaller):
+
+    @checkpoint_decorator("prerequisites", "System preparations already done.")
+    def _install_prerequisites(self):
+        self.run("dnf --refresh install -y kernel kernel-devel kernel-headers gcc gcc-c++ make")
+        raise RebootRequired
+
+    def uninstall_cuda(self):
+        pass
+
+    def verify_cuda(self) -> bool:
+        pass

--- a/linux/cuda_installer/os_installers/rocky.py
+++ b/linux/cuda_installer/os_installers/rocky.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from os_installers.rhel import RHELInstaller
 
 

--- a/linux/cuda_installer/os_installers/rocky.py
+++ b/linux/cuda_installer/os_installers/rocky.py
@@ -1,0 +1,9 @@
+from os_installers.rhel import RHELInstaller
+
+
+# Turns out, Rocky is so similar to Red Hat, that the same installation process works for both.
+# Unfortunately, Rocky 8 comes without lspci, so it needs to be installed before checking what GPU we're facing.
+class RockyInstaller(RHELInstaller):
+    def __init__(self):
+        self.run("dnf install -y pciutils", silent=True)
+        RHELInstaller.__init__(self)

--- a/linux/cuda_installer/os_installers/ubuntu.py
+++ b/linux/cuda_installer/os_installers/ubuntu.py
@@ -1,6 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from decorators import checkpoint_decorator
-from os_installers import LinuxInstaller, RebootRequired
 from logger import logger
+from os_installers import LinuxInstaller, RebootRequired
 
 
 class UbuntuInstaller(LinuxInstaller):
@@ -12,8 +26,10 @@ class UbuntuInstaller(LinuxInstaller):
         """
         self.run("apt-get update", silent=True)
 
-        self.run("apt-get install -y linux-image-gcp linux-headers-gcp "
-                 "gcc make dkms pciutils software-properties-common")
+        self.run(
+            "apt-get install -y linux-image-gcp linux-headers-gcp "
+            "gcc make dkms pciutils software-properties-common"
+        )
         raise RebootRequired
 
     def lock_kernel_updates(self):
@@ -21,19 +37,23 @@ class UbuntuInstaller(LinuxInstaller):
         Marks kernel related packages, so they don't get auto-updated. This would cause the driver to stop working.
         """
         logger.info("Locking kernel updates...")
-        self.run(f"apt-mark hold "
-                 f"linux-image-gcp "
-                 f"linux-headers-gcp "
-                 f"linux-image-{self.kernel_version} "
-                 f"linux-headers-{self.kernel_version}")
+        self.run(
+            f"apt-mark hold "
+            f"linux-image-gcp "
+            f"linux-headers-gcp "
+            f"linux-image-{self.kernel_version} "
+            f"linux-headers-{self.kernel_version}"
+        )
 
     def unlock_kernel_updates(self):
         """
         Allows the kernel related packages to be upgraded.
         """
         logger.info("Unlocking kernel updates...")
-        self.run(f"apt-mark unhold "
-                 f"linux-image-gcp "
-                 f"linux-headers-gcp "
-                 f"linux-image-{self.kernel_version} "
-                 f"linux-headers-{self.kernel_version}")
+        self.run(
+            f"apt-mark unhold "
+            f"linux-image-gcp "
+            f"linux-headers-gcp "
+            f"linux-image-{self.kernel_version} "
+            f"linux-headers-{self.kernel_version}"
+        )

--- a/linux/cuda_installer/os_installers/ubuntu.py
+++ b/linux/cuda_installer/os_installers/ubuntu.py
@@ -37,9 +37,3 @@ class UbuntuInstaller(LinuxInstaller):
                  f"linux-headers-gcp "
                  f"linux-image-{self.kernel_version} "
                  f"linux-headers-{self.kernel_version}")
-
-    def uninstall_cuda(self):
-        pass
-
-    def verify_cuda(self) -> bool:
-        pass

--- a/linux/cuda_installer/os_installers/ubuntu.py
+++ b/linux/cuda_installer/os_installers/ubuntu.py
@@ -1,0 +1,45 @@
+from decorators import checkpoint_decorator
+from os_installers import LinuxInstaller, RebootRequired
+from logger import logger
+
+
+class UbuntuInstaller(LinuxInstaller):
+
+    @checkpoint_decorator("prerequisites", "System preparations already done.")
+    def _install_prerequisites(self):
+        """
+        Installs packages required for the proper driver installation on Debian.
+        """
+        self.run("apt-get update", silent=True)
+
+        self.run("apt-get install -y linux-image-gcp linux-headers-gcp "
+                 "gcc make dkms pciutils software-properties-common")
+        raise RebootRequired
+
+    def lock_kernel_updates(self):
+        """
+        Marks kernel related packages, so they don't get auto-updated. This would cause the driver to stop working.
+        """
+        logger.info("Locking kernel updates...")
+        self.run(f"apt-mark hold "
+                 f"linux-image-gcp "
+                 f"linux-headers-gcp "
+                 f"linux-image-{self.kernel_version} "
+                 f"linux-headers-{self.kernel_version}")
+
+    def unlock_kernel_updates(self):
+        """
+        Allows the kernel related packages to be upgraded.
+        """
+        logger.info("Unlocking kernel updates...")
+        self.run(f"apt-mark unhold "
+                 f"linux-image-gcp "
+                 f"linux-headers-gcp "
+                 f"linux-image-{self.kernel_version} "
+                 f"linux-headers-{self.kernel_version}")
+
+    def uninstall_cuda(self):
+        pass
+
+    def verify_cuda(self) -> bool:
+        pass

--- a/linux/install_gpu_driver.py
+++ b/linux/install_gpu_driver.py
@@ -19,9 +19,12 @@ import re
 import shlex
 import subprocess
 import sys
+import warnings
 from datetime import datetime
 from enum import Enum, auto
 from typing import Optional
+
+warnings.warn("This script is being deprecated. Please use cuda_installer as replacement.", DeprecationWarning)
 
 DRIVER_VERSION = "525.125.06"
 K80_DRIVER_VERSION = "470.199.02"

--- a/linux/tests/requirements.txt
+++ b/linux/tests/requirements.txt
@@ -1,3 +1,5 @@
-pytest==7.1.1
-pytest-parallel==0.1.1
-google-cloud-compute==1.1.0
+pytest>=8.2.0
+pytest-xdist>=3.6.1
+google-cloud-compute>=1.18.0
+google-cloud-storage>=2.16.0
+google-cloud-iam>=2.15.0

--- a/linux/tests/startup_script.sh
+++ b/linux/tests/startup_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if test -f /opt/google/cuda-installer/
+then
+  exit
+fi
+
+mkdir -p /opt/google/cuda-installer/
+cd /opt/google/cuda-installer/ || exit
+
+gsutil cp {GS_INSTALLER_PATH} cuda_installer.pyz
+python3 cuda_installer.pyz install_cuda


### PR DESCRIPTION
Fixes #34 
Fixes #33 
Fixes #31 

# About the installer

Since the script that was published so far has frequently failed to properly install the drivers, or the drivers stopped working after installation (and system update), I decided to look into this more closely. As a result, here's a new installation tool, that should provide a better installation experience and be easier to manage than a big single Python file.

# What's new?

* The installer will be distributed as a single [PYZ file](https://docs.python.org/3/library/zipapp.html). This allows me to organize code into separate files and make it more manageable.
* The installer will not only install GPU drivers, but also CUDA Toolkit.
* After installation, the installer will attempt to block kernel updates in the system, as they were the root cause of all the failures in the previous approach. With this approach, to update the kernel, user will have to uninstall the drivers, update the kernel and install the drivers again. Or just start a new instance with fresh, updated kernel.
* The tool knows how to uninstall GPU drivers.
* CUDA Toolkit installation also installs [nvidia-persistenced](https://download.nvidia.com/XFree86/Linux-x86_64/396.51/README/nvidia-persistenced.html) daemon.
* The tool verifies the downloaded NVIDIA installer against hardcoded SHA256 checksum.
* The tool can verify CUDA toolkit installation by executing 2 code samples from CUDA samples public code repository.

# New distribution process

Starting with this PR, the installation tool for Linux will be distributed using the Releasing system on GitHub as PYZ files. This will provide better use experience, since users will be able to rely on immutable version of the tool.

Nothing changes for Windows installation script, it still has to be grabbed from the `main` branch.

# K80 support

K80 GPUs get limited support. The tool can install GPU drivers, but no CUDA Toolkit.

# Operating systems

Right now only RHEL, Rocky, Debian and Ubuntu are supported. However, with the new architecture, support for other systems should be easier to add, if there are any requests for them.

Support for [Secure Boot](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm) systems is on the roadmap.

